### PR TITLE
Details panel has spurious padding at the top and bottom

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageOverviewInfo.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageOverviewInfo.kt
@@ -48,7 +48,7 @@ internal fun PackageOverviewTab(
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp),
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize().padding(start = 4.dp)
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
@@ -57,7 +57,7 @@ fun PackageSearchInfoPanel(
             Box(modifier = Modifier.fillMaxWidth()) {
                 Column(
                     modifier = Modifier
-                        .padding(start = 4.dp, end = PackageSearchMetrics.scrollbarWidth)
+                        .padding(end = PackageSearchMetrics.scrollbarWidth)
                         .verticalScroll(viewModel.scrollState)
                 ) {
                     val tab = activeTab


### PR DESCRIPTION
[PKGS-1298](https://youtrack.jetbrains.com/issue/PKGS-1298/Compose-UI-Details-panel-has-spurious-padding-at-the-top-and-bottom)