### PR TITLE
Fix search glitch on module selection change

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
@@ -136,6 +136,13 @@ class PackageListViewModel(
                     else -> value
                 }
             }
+        }.modifiedBy(selectedModulesFlow) { current: Map<PackageListItem.Header.Id.Remote, Search>, change ->
+            val changeIdentities = change.map { it.identity }
+            if (current.keys.any { it.moduleIdentity !in changeIdentities }) {
+                emptyMap()
+            } else {
+                current
+            }
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 


### PR DESCRIPTION
[PKGS-1319](https://youtrack.jetbrains.com/agiles/153-2382/current?issue=PKGS-1319)

when module selection changes, the query results were kept showing for a while (until the next search for new modules selection is complete) like the following video shows

Then:

https://github.com/JetBrains/package-search-intellij-plugin/assets/36624359/bf0bcca7-9a47-4bc0-83c4-058af3db573a


Now:

https://github.com/JetBrains/package-search-intellij-plugin/assets/36624359/d10434f4-3cc0-4cee-9f29-9737ff519259


