### PR TITLE
Rollback to Compose Foundation SplitPane

### DIFF
--- a/packagesearch.versions.toml
+++ b/packagesearch.versions.toml
@@ -39,6 +39,7 @@ jewel-ui = { module = "org.jetbrains.jewel:jewel-ui", version.ref = "jewel" }
 jewel-foundation = { module = "org.jetbrains.jewel:jewel-foundation", version.ref = "jewel" }
 jewel-bridge-ij232 = { module = "org.jetbrains.jewel:jewel-ide-laf-bridge", version.ref = "jewel-bridge-232" }
 jewel-bridge-ij233 = { module = "org.jetbrains.jewel:jewel-ide-laf-bridge", version.ref = "jewel-bridge-233" }
+compose-desktop-components-splitpane = { module = "org.jetbrains.compose.components:components-splitpane", version.ref = "composeDesktop" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -50,6 +50,10 @@ val tooling: Configuration by configurations.creating {
 
 dependencies {
     implementation(packageSearchCatalog.kotlinx.serialization.core)
+    implementation(packageSearchCatalog.compose.desktop.components.splitpane){
+        exclude(group = "org.jetbrains.compose.runtime")
+        exclude(group = "org.jetbrains.compose.foundation")
+    }
     implementation(packageSearchCatalog.ktor.client.logging)
     implementation(packageSearchCatalog.packagesearch.api.models)
     implementation(projects.plugin.gradle.base)

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchMetrics.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchMetrics.kt
@@ -19,6 +19,14 @@ object PackageSearchMetrics {
                     metrics.trackPadding.calculateEndPadding(LocalLayoutDirection.current)
         }
 
+    object Splitpane {
+
+        val minWidth: Dp = 300.dp
+        const val firstSplitterPositionPercentage = .20f
+
+        const val secondSplittePositionPercentage = .80f
+    }
+
     object Popups {
 
         val minWidth: Dp = 50.dp
@@ -54,5 +62,4 @@ object PackageSearchMetrics {
             }
         }
     }
-
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
@@ -1,11 +1,17 @@
 package com.jetbrains.packagesearch.plugin.ui.bridge
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -15,8 +21,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import com.intellij.icons.AllIcons
 import com.jetbrains.packagesearch.plugin.ui.PackageSearchMetrics
+import java.awt.Cursor
+import org.jetbrains.compose.splitpane.SplitPaneScope
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalTextStyle
 import org.jetbrains.jewel.ui.component.DropdownLink
@@ -127,6 +136,38 @@ internal fun PackageActionPopup(
                 ),
                 content = content
             )
+        }
+    }
+}
+
+
+
+internal fun SplitPaneScope.packageSearchSplitter(
+    splitterColor: Color,
+    cursor: PointerIcon = PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR)),
+    hidden: Boolean = false,
+) {
+    splitter {
+        visiblePart {
+            if (!hidden) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(1.dp)
+                        .background(splitterColor),
+                )
+            }
+        }
+        handle {
+            if (!hidden) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(8.dp)
+                        .markAsHandle()
+                        .pointerHoverIcon(cursor),
+                )
+            }
         }
     }
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
@@ -1,11 +1,13 @@
 package com.jetbrains.packagesearch.plugin.ui.model
 
+import androidx.compose.runtime.mutableStateOf
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.Service.Level
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.jetbrains.packagesearch.plugin.PackageSearchBundle.message
 import com.jetbrains.packagesearch.plugin.core.utils.smartModeFlow
+import com.jetbrains.packagesearch.plugin.ui.PackageSearchMetrics
 import com.jetbrains.packagesearch.plugin.ui.bridge.openLinkInBrowser
 import com.jetbrains.packagesearch.plugin.ui.model.tree.TreeViewModel
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchProjectService
@@ -18,9 +20,24 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import org.jetbrains.compose.splitpane.SplitPaneState
 
 @Service(Level.PROJECT)
 class ToolWindowViewModel(project: Project, private val viewModelScope: CoroutineScope) {
+
+
+    val firstSplitPaneState = mutableStateOf(
+        SplitPaneState(
+            initialPositionPercentage = PackageSearchMetrics.Splitpane.firstSplitterPositionPercentage,
+            moveEnabled = true,
+        )
+    )
+    val secondSplitPaneState = mutableStateOf(
+        SplitPaneState(
+            initialPositionPercentage = PackageSearchMetrics.Splitpane.secondSplittePositionPercentage,
+            moveEnabled = true,
+        )
+    )
 
     fun openLinkInBrowser(url: String) {
         viewModelScope.openLinkInBrowser(url)

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/PackageSearchCentralPanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/PackageSearchCentralPanel.kt
@@ -19,7 +19,7 @@ import org.jetbrains.jewel.ui.component.VerticalScrollbar
 
 @Composable
 fun PackageSearchCentralPanel(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     onLinkClick: (String) -> Unit,
 ) = Column(modifier) {
     val viewModel: PackageListViewModel = viewModel()

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
@@ -28,7 +28,7 @@ import org.jetbrains.jewel.ui.component.VerticalScrollbar
 
 @Composable
 fun PackageSearchInfoPanel(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     onLinkClick: (String) -> Unit,
     onPackageEvent: (PackageListItemEvent) -> Unit,
 ) = Box(modifier) {


### PR DESCRIPTION
Referring to [PKGS-1335](https://youtrack.jetbrains.com/issue/PKGS-1335/Info-panel-default-size-is-too-big)
Rollback to Compose Foundation SplitPane, waiting fix for the jewel's one