### PR TITLE
PKGS-1350 Fix package popup falls out of the visible area

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
@@ -130,7 +130,7 @@ internal fun PackageActionPopup(
         }
         if (isOpen) {
             PopupMenu(
-                horizontalAlignment = Alignment.Start,
+                horizontalAlignment = Alignment.End,
                 onDismissRequest = { _ ->
                     onDismissRequest()
                     true


### PR DESCRIPTION
see [PKGS-1350](https://youtrack.jetbrains.com/issue/PKGS-1350/UI-Package-action-popup-go-out-of-visible-area)
Change alignment of PopupMenu to end