### PR TITLE
Fix badges resize-arrangement policy in sidePane - PlatformPane

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/bridge/Components.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -22,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.intellij.icons.AllIcons
@@ -183,8 +186,50 @@ internal fun AttributeBadge(text: String, onClick: () -> Unit) {
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp), text = text,
         )
     }
-
 }
+
+@Composable
+internal fun FlowRow(
+    xSpacing: Dp = 0.dp,
+    ySpacing: Dp = 0.dp,
+    content: @Composable () -> Unit,
+) {
+    Layout(
+        content = content
+    ) { measurables, constraints ->
+        val childConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+        val placeables = measurables.map { it.measure(childConstraints) }
+
+        val rows = mutableListOf<List<Placeable>>()
+        var currentRow = mutableListOf<Placeable>()
+        var currentWidth = 0
+
+        placeables.forEach { placeable ->
+            if (currentWidth + placeable.width > constraints.maxWidth) {
+                rows.add(currentRow)
+                currentRow = mutableListOf()
+                currentWidth = 0
+            }
+            currentRow.add(placeable)
+            currentWidth += placeable.width + xSpacing.roundToPx()
+        }
+        rows.add(currentRow)
+
+        val height = rows.sumOf { it.maxOf { it.height } + ySpacing.roundToPx() } - ySpacing.roundToPx()
+        layout(constraints.maxWidth, height) {
+            var yPosition = 0
+            rows.forEach { row ->
+                var xPosition = 0
+                row.forEach { placeable ->
+                    placeable.placeRelative(xPosition, yPosition)
+                    xPosition += placeable.width + xSpacing.roundToPx()
+                }
+                yPosition += row.maxOf { it.height } + ySpacing.roundToPx()
+            }
+        }
+    }
+}
+
 
 //@Preview
 //@Composable

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import com.jetbrains.packagesearch.plugin.PackageSearchBundle
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModuleVariant
 import com.jetbrains.packagesearch.plugin.ui.bridge.AttributeBadge
+import com.jetbrains.packagesearch.plugin.ui.bridge.FlowRow
 import com.jetbrains.packagesearch.plugin.ui.bridge.LabelInfo
 import com.jetbrains.packagesearch.plugin.ui.model.infopanel.InfoPanelContent
 import kotlin.math.roundToInt
@@ -67,8 +68,7 @@ private fun HeaderAttributesTabImpl(
             )
         }
 
-
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        FlowRow(xSpacing = 4.dp) {
             attributes.forEachIndexed { index, attribute ->
                 AttributeBadge(text = attribute.value) {
                     scope.scrollToAttribute(scrollState, attributeGlobalPositionMap, index)
@@ -238,49 +238,50 @@ private fun generateAttributesMock(): List<PackageSearchModuleVariant.Attribute>
 
 }
 
-internal val platformListMock get() =  buildList {
-    add("Android")
-    add("android")
-    add("Apple")
-    add("iOS")
-    add("iosX64")
-    add("iosArm64")
-    add("iosSimulatorArm64")
-    add("macOS")
-    add("macosArm64")
-    add("macosX64")
+internal val platformListMock
+    get() = buildList {
+        add("Android")
+        add("android")
+        add("Apple")
+        add("iOS")
+        add("iosX64")
+        add("iosArm64")
+        add("iosSimulatorArm64")
+        add("macOS")
+        add("macosArm64")
+        add("macosX64")
 
-    add("watchOS")
-    add("watchosArm32")
-    add("watchosArm64")
-    add("watchosX64")
-    add("watchosSimulatorArm64")
+        add("watchOS")
+        add("watchosArm32")
+        add("watchosArm64")
+        add("watchosX64")
+        add("watchosSimulatorArm64")
 
-    add("tvOS")
-    add("tvosX64")
-    add("tvosArm64")
-    add("tvosSimulatorArm64")
+        add("tvOS")
+        add("tvosX64")
+        add("tvosArm64")
+        add("tvosSimulatorArm64")
 
 
-    add("Java")
-    add("jvm")
+        add("Java")
+        add("jvm")
 
-    add("JavaScript")
-    add("jsLegacy")
-    add("jslr")
+        add("JavaScript")
+        add("jsLegacy")
+        add("jslr")
 
-    add("Linux")
-    add("LinuxMipsel32")
-    add("LinuxArm64")
-    add("LinuxArm32Hfp")
-    add("LinuxX64")
+        add("Linux")
+        add("LinuxMipsel32")
+        add("LinuxArm64")
+        add("LinuxArm32Hfp")
+        add("LinuxX64")
 
-    add("Windows")
-    add("WindowsX64")
-    add("WindowsX86")
+        add("Windows")
+        add("WindowsX64")
+        add("WindowsX86")
 
-    add("WebAssembly")
-    add("wasm")
-    add("wasm32")
+        add("WebAssembly")
+        add("wasm")
+        add("wasm32")
 
-}
+    }


### PR DESCRIPTION
Now badges in the Platform Pane (side panel on the right) will be wrapped instead of resize/clipped