### PR TITLE
232-Fix badge resize arrangement policy in sidePane - PlatformPane

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import com.jetbrains.packagesearch.plugin.PackageSearchBundle
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModuleVariant
 import com.jetbrains.packagesearch.plugin.ui.bridge.AttributeBadge
+import com.jetbrains.packagesearch.plugin.ui.bridge.FlowRow
 import com.jetbrains.packagesearch.plugin.ui.bridge.LabelInfo
 import com.jetbrains.packagesearch.plugin.ui.model.infopanel.InfoPanelContent
 import kotlin.math.roundToInt
@@ -67,8 +68,7 @@ private fun HeaderAttributesTabImpl(
             )
         }
 
-
-        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        FlowRow(xSpacing = 4.dp) {
             attributes.forEachIndexed { index, attribute ->
                 AttributeBadge(text = attribute.value) {
                     scope.scrollToAttribute(scrollState, attributeGlobalPositionMap, index)


### PR DESCRIPTION
Now badges in the Platform Pane (side panel on the right) will be wrapped instead of resize/clipped