### PR TITLE
Align API for bundled Jewel Version

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/tree/PackageSearchModulesTree.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/tree/PackageSearchModulesTree.kt
@@ -55,7 +55,7 @@ fun PackageSearchModulesTree(
         onExpandAll = viewModel::expandAll,
         onCollapseAll = {
             val rootIds = tree.roots.map { it.id }.toSet()
-            viewModel.treeState.selectedKeys = viewModel.treeState.selectedKeys intersect rootIds
+            viewModel.treeState.selectedKeys = (viewModel.treeState.selectedKeys intersect rootIds).toList()
             viewModel.collapseAll()
         },
     )
@@ -74,7 +74,7 @@ fun PackageSearchModulesTree(
             viewModel.treeState.selectedKeys = tree.walkBreadthFirst()
                 .take(1)
                 .map { it.data.id }
-                .toSet()
+                .toList()
         }
     }
     Box {


### PR DESCRIPTION
Align the assignment of selected keys in PackageSearchModulesTree as required for the current version of Jewel in EAP