### PR TITLE
232 - Fix InfoPanel Tab paddings

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import com.jetbrains.packagesearch.plugin.PackageSearchBundle
 import com.jetbrains.packagesearch.plugin.ui.PackageSearchMetrics
 import com.jetbrains.packagesearch.plugin.ui.bridge.LabelInfo
@@ -48,7 +49,9 @@ fun PackageSearchInfoPanel(
                         selected = activeTabTitle == infoPanelContent.tabTitle,
                         closable = false,
                         content = { tabState ->
-                            SimpleTabContent(infoPanelContent.tabTitle, tabState)
+                            Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+                                SimpleTabContent(infoPanelContent.tabTitle, tabState)
+                            }
                         },
                         onClick = { viewModel.setActiveTabTitle(infoPanelContent.tabTitle) },
                     )


### PR DESCRIPTION
fixes paddings for tabs in Infobox Tabstrip
<img width="144" alt="image" src="https://github.com/JetBrains/package-search-intellij-plugin/assets/36624359/3b10fe0e-00da-48d0-888a-1cd777b3f78e">
