### PR TITLE
Fixed KMP-Platforms and attribute information in infoPanel (#30)

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchDeclaredPackage.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchDeclaredPackage.kt
@@ -1,6 +1,8 @@
 package com.jetbrains.packagesearch.plugin.core.data
 
 import com.jetbrains.packagesearch.plugin.core.extensions.DependencyDeclarationIndexes
+import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
+import org.jetbrains.packagesearch.api.v3.ApiMavenPackage.GradleVersion.ApiVariant
 import org.jetbrains.packagesearch.api.v3.ApiPackage
 import org.jetbrains.packagesearch.packageversionutils.normalization.NormalizedVersion
 
@@ -20,3 +22,39 @@ interface PackageSearchDeclaredPackage : IconProvider {
     val declaredScope: String?
 
 }
+
+
+fun PackageSearchDeclaredPackage.listKMPAttributesNames(onlyStable: Boolean): Set<String> {
+    val version = getLatestVersion(onlyStable) as? ApiMavenPackage.GradleVersion ?: return emptySet()
+    return version.listKMPAttributesNames()
+}
+
+fun ApiPackage.listKMPAttributesNames(onlyStable: Boolean): Set<String> {
+    val version = getLatestVersion(onlyStable) as? ApiMavenPackage.GradleVersion ?: return emptySet()
+    return version.listKMPAttributesNames()
+}
+
+fun ApiMavenPackage.GradleVersion.listKMPAttributesNames(): Set<String> = buildSet {
+    for (apiVariant in variants) {
+        val variantAttributes =
+            apiVariant.attributes["org.jetbrains.kotlin.platform.type"] as? ApiVariant.Attribute.ExactMatch
+                ?: continue
+        when (variantAttributes.value) {
+            "native" ->
+                when (val target = apiVariant.attributes["org.jetbrains.kotlin.native.target"]) {
+                    is ApiVariant.Attribute.ExactMatch -> add(target.value)
+                    else -> continue
+                }
+
+            "common" -> continue
+            else -> add(variantAttributes.value)
+        }
+    }
+}
+
+fun PackageSearchDeclaredPackage.getLatestVersion(onlyStable: Boolean) =
+    if (onlyStable) remoteInfo?.versions?.latestStable else remoteInfo?.versions?.latest
+
+fun ApiPackage.getLatestVersion(onlyStable: Boolean) =
+    if (onlyStable) versions.latestStable else versions.latest
+

--- a/plugin/gradle/kmp/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/KMPAttributes.kt
+++ b/plugin/gradle/kmp/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/KMPAttributes.kt
@@ -1,47 +1,20 @@
 package com.jetbrains.packagesearch.plugin.gradle
 
-import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModuleVariant
 
-object KMPAttributes {
-    val iosArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("ios_arm64")
-    val iosX64 = PackageSearchModuleVariant.Attribute.StringAttribute("ios_x64")
-    val ios = PackageSearchModuleVariant.Attribute.NestedAttribute("iOS", listOf(iosArm64, iosX64))
+data class KmpAttributesGroups(
+    val displayName: String,
+    val aggregationKeyword: String = displayName,
+)
 
-    val macosX64 = PackageSearchModuleVariant.Attribute.StringAttribute("macos_x64")
-    val macosArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("macos_arm64")
-    val macos = PackageSearchModuleVariant.Attribute.NestedAttribute("macOs", listOf(macosX64, macosArm64))
-
-    val watchosArm32 = PackageSearchModuleVariant.Attribute.StringAttribute("watchos_arm32")
-    val watchosArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("watchos_arm64")
-    val watchosX64 = PackageSearchModuleVariant.Attribute.StringAttribute("watchos_x64")
-    val watchosDevice =
-        PackageSearchModuleVariant.Attribute.NestedAttribute("watchOs", listOf(watchosArm32, watchosArm64))
-    val watchos = PackageSearchModuleVariant.Attribute.NestedAttribute("watchOs", listOf(watchosDevice, watchosX64))
-
-    val tvosArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("tvos_arm64")
-    val tvosX64 = PackageSearchModuleVariant.Attribute.StringAttribute("tvos_x64")
-    val tvos = PackageSearchModuleVariant.Attribute.NestedAttribute("tvOs", listOf(tvosArm64, tvosX64))
-
-    val apple = PackageSearchModuleVariant.Attribute.NestedAttribute("Apple", listOf(ios, macos, watchos, tvos))
-
-    val jsLegacy = PackageSearchModuleVariant.Attribute.StringAttribute("jsLegacy")
-    val jsIr = PackageSearchModuleVariant.Attribute.StringAttribute("jsIr")
-    val js = PackageSearchModuleVariant.Attribute.NestedAttribute("JavaScript", listOf(jsLegacy, jsIr))
-
-    val linuxArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("linuxArm64")
-    val linuxX64 = PackageSearchModuleVariant.Attribute.StringAttribute("linuxX64")
-    val linux = PackageSearchModuleVariant.Attribute.NestedAttribute("Linux", listOf(linuxArm64, linuxX64))
-
-    val android = PackageSearchModuleVariant.Attribute.StringAttribute("android")
-
-    val androidArm32 = PackageSearchModuleVariant.Attribute.StringAttribute("androidArm32")
-    val androidArm64 = PackageSearchModuleVariant.Attribute.StringAttribute("androidArm64")
-    val androidX64 = PackageSearchModuleVariant.Attribute.StringAttribute("androidX64")
-    val androidX86 = PackageSearchModuleVariant.Attribute.StringAttribute("androidX86")
-    val androidNative =
-        PackageSearchModuleVariant.Attribute.NestedAttribute(
-            "Android Native",
-            listOf(androidArm32, androidArm64, androidX64, androidX86)
-        )
-
-}
+val KMP_ATTRIBUTES_GROUPS = listOf(
+    KmpAttributesGroups("iOS"),
+    KmpAttributesGroups("macOS"),
+    KmpAttributesGroups("tvOS"),
+    KmpAttributesGroups("watchOS"),
+    KmpAttributesGroups("JS"),
+    KmpAttributesGroups("JVM"),
+    KmpAttributesGroups("Linux"),
+    KmpAttributesGroups("Android"),
+    KmpAttributesGroups("WASM"),
+    KmpAttributesGroups("Windows", "mingw"),
+)

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelContent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelContent.kt
@@ -7,7 +7,12 @@ import com.jetbrains.packagesearch.plugin.ui.model.packageslist.PackageListItem
 
 sealed interface InfoPanelContent {
 
-    val tabTitle: String
+    data class TabTitleData(
+        val tabTitle: String,
+        val quantity: Int? = null,
+    )
+
+    val tabTitleData: TabTitleData
 
     sealed interface PackageInfo : InfoPanelContent {
 
@@ -52,7 +57,7 @@ sealed interface InfoPanelContent {
 
             data class Base(
                 override val packageListId: PackageListItem.Package.Declared.Id.Base,
-                override val tabTitle: String,
+                override val tabTitleData: TabTitleData,
                 override val moduleId: PackageSearchModule.Identity,
                 override val title: String,
                 override val subtitle: String,
@@ -70,12 +75,12 @@ sealed interface InfoPanelContent {
                 override val availableVersions: List<String>,
                 override val declaredScope: String,
                 override val availableScopes: List<String>,
-                override val allowMissingScope: Boolean
-                ) : Declared
+                override val allowMissingScope: Boolean,
+            ) : Declared
 
             data class WithVariant(
                 override val packageListId: PackageListItem.Package.Declared.Id.WithVariant,
-                override val tabTitle: String,
+                override val tabTitleData: TabTitleData,
                 override val moduleId: PackageSearchModule.Identity,
                 override val title: String,
                 override val subtitle: String,
@@ -96,7 +101,7 @@ sealed interface InfoPanelContent {
                 override val allowMissingScope: Boolean,
                 val declaredVariant: String,
                 val compatibleVariants: List<String>,
-                val variantTerminology: PackageSearchModule.WithVariants.Terminology
+                val variantTerminology: PackageSearchModule.WithVariants.Terminology,
             ) : Declared
         }
 
@@ -104,7 +109,7 @@ sealed interface InfoPanelContent {
 
             data class Base(
                 override val packageListId: PackageListItem.Package.Remote.Base.Id,
-                override val tabTitle: String,
+                override val tabTitleData: TabTitleData,
                 override val moduleId: PackageSearchModule.Identity,
                 override val title: String,
                 override val subtitle: String,
@@ -121,7 +126,7 @@ sealed interface InfoPanelContent {
 
             data class WithVariant(
                 override val packageListId: PackageListItem.Package.Remote.WithVariant.Id,
-                override val tabTitle: String,
+                override val tabTitleData: TabTitleData,
                 override val moduleId: PackageSearchModule.Identity,
                 override val title: String,
                 override val subtitle: String,
@@ -144,14 +149,19 @@ sealed interface InfoPanelContent {
     sealed interface Attributes : InfoPanelContent {
         val attributes: List<PackageSearchModuleVariant.Attribute>
 
-        data class FromVariant(
-            override val tabTitle: String,
+        data class FromPackage(
+            override val attributes: List<PackageSearchModuleVariant.Attribute>,
+            override val tabTitleData: TabTitleData,
+        ) : Attributes
+
+        data class FromVariantHeader(
+            override val tabTitleData: TabTitleData,
             val variantName: String,
             override val attributes: List<PackageSearchModuleVariant.Attribute>,
         ) : Attributes
 
-        data class FromSearch(
-            override val tabTitle: String,
+        data class FromSearchHeader(
+            override val tabTitleData: TabTitleData,
             override val attributes: List<PackageSearchModuleVariant.Attribute>,
             val defaultSourceSet: String,
             val additionalSourceSets: List<String>,
@@ -159,3 +169,4 @@ sealed interface InfoPanelContent {
     }
 
 }
+

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
@@ -59,10 +59,10 @@ class InfoPanelViewModel(private val project: Project) : Disposable {
                             event.asPanelContent(onlyStable, isLoading)
 
                         is InfoPanelContentEvent.Package.Remote.Base ->
-                            event.asPanelContent(isLoading)
+                            event.asPanelContent(onlyStable, isLoading)
 
                         is InfoPanelContentEvent.Package.Remote.WithVariants ->
-                            event.asPanelContent(isLoading)
+                            event.asPanelContent(onlyStable, isLoading)
                     }
                 }
             }
@@ -88,10 +88,10 @@ class InfoPanelViewModel(private val project: Project) : Disposable {
 
     init {
         combine(
-            tabs.map { it.map { it.tabTitle } },
+            tabs.map { it.map { it.tabTitleData } },
             activeTabTitleMutableStateFlow
         ) { tabTitles, activeTabTitle ->
-            if (activeTabTitle !in tabTitles) tabTitles.firstOrNull() else activeTabTitle
+            if (activeTabTitle !in tabTitles.map { it.tabTitle }) tabTitles.firstOrNull()?.tabTitle else activeTabTitle
         }
             .mapNotNull { it }
             .onEach { activeTabTitleMutableStateFlow.emit(it) }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
@@ -3,8 +3,10 @@ package com.jetbrains.packagesearch.plugin.ui.model.infopanel
 import com.jetbrains.packagesearch.plugin.PackageSearchBundle.message
 import com.jetbrains.packagesearch.plugin.core.data.IconProvider
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredPackage
+import com.jetbrains.packagesearch.plugin.core.data.listKMPAttributesNames
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchKnownRepositoriesContext
 import com.jetbrains.packagesearch.plugin.core.utils.icon
+import com.jetbrains.packagesearch.plugin.gradle.buildAttributesFromRawStrings
 import com.jetbrains.packagesearch.plugin.ui.model.getLatestVersion
 import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
 import org.jetbrains.packagesearch.api.v3.ApiPackage
@@ -20,40 +22,44 @@ context(PackageSearchKnownRepositoriesContext)
 internal fun InfoPanelContentEvent.Package.Declared.Base.asPanelContent(
     onlyStable: Boolean,
     isLoading: Boolean,
-) = listOf(
-    InfoPanelContent.PackageInfo.Declared.Base(
-        moduleId = module.identity,
-        packageListId = packageListId,
-        tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview"),
-        title = declaredPackage.displayName,
-        subtitle = declaredPackage.coordinates,
-        icon = declaredPackage.icon,
-        type = declaredPackage.typeInfo,
-        licenses = declaredPackage.remoteInfo?.licenses?.asInfoPanelLicenseList() ?: emptyList(),
-        authors = declaredPackage.remoteInfo?.authors?.mapNotNull { it.name } ?: emptyList(),
-        description = declaredPackage.remoteInfo
-            ?.description
-            ?.sanitizeDescription(),
-        scm = declaredPackage.remoteInfo?.scm?.asInfoPanelScm(),
-        readmeUrl = declaredPackage.remoteInfo?.scm?.readme?.htmlUrl ?: declaredPackage.remoteInfo?.scm?.readmeUrl,
-        repositories = declaredPackage.remoteInfo?.repositories() ?: emptyList(),
-        latestVersion = declaredPackage.getLatestVersion(onlyStable)?.versionName,
-        declaredVersion = declaredPackage.declaredVersion
-            ?.versionName
-            ?: message("packagesearch.ui.missingVersion"),
-        declaredScope = declaredPackage.declaredScope
-            ?: message("packagesearch.ui.missingScope"),
-        availableVersions = declaredPackage.remoteInfo
-            ?.versions
-            ?.all
-            ?.filter { if (onlyStable) it.normalizedVersion.isStable else true }
-            ?.map { it.normalizedVersion.versionName }
-            ?: emptyList(),
-        availableScopes = module.availableScopes,
-        isLoading = isLoading,
-        allowMissingScope = !module.dependencyMustHaveAScope
+) = buildList {
+    add(
+        InfoPanelContent.PackageInfo.Declared.Base(
+            moduleId = module.identity,
+            packageListId = packageListId,
+            tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview")),
+            title = declaredPackage.displayName,
+            subtitle = declaredPackage.coordinates,
+            icon = declaredPackage.icon,
+            type = declaredPackage.typeInfo,
+            licenses = declaredPackage.remoteInfo?.licenses?.asInfoPanelLicenseList() ?: emptyList(),
+            authors = declaredPackage.remoteInfo?.authors?.mapNotNull { it.name } ?: emptyList(),
+            description = declaredPackage.remoteInfo
+                ?.description
+                ?.sanitizeDescription(),
+            scm = declaredPackage.remoteInfo?.scm?.asInfoPanelScm(),
+            readmeUrl = declaredPackage.remoteInfo?.scm?.readme?.htmlUrl ?: declaredPackage.remoteInfo?.scm?.readmeUrl,
+            repositories = declaredPackage.remoteInfo?.repositories() ?: emptyList(),
+            latestVersion = declaredPackage.getLatestVersion(onlyStable)?.versionName,
+            declaredVersion = declaredPackage.declaredVersion
+                ?.versionName
+                ?: message("packagesearch.ui.missingVersion"),
+            declaredScope = declaredPackage.declaredScope
+                ?: message("packagesearch.ui.missingScope"),
+            availableVersions = declaredPackage.remoteInfo
+                ?.versions
+                ?.all
+                ?.filter { if (onlyStable) it.normalizedVersion.isStable else true }
+                ?.map { it.normalizedVersion.versionName }
+                ?: emptyList(),
+            availableScopes = module.availableScopes,
+            isLoading = isLoading,
+            allowMissingScope = !module.dependencyMustHaveAScope
+        )
     )
-)
+    addAttributesFromNames(declaredPackage.listKMPAttributesNames(onlyStable))
+}
+
 
 internal val PackageSearchDeclaredPackage.typeInfo: InfoPanelContent.PackageInfo.Type?
     get() {
@@ -91,115 +97,128 @@ context(PackageSearchKnownRepositoriesContext)
 internal fun InfoPanelContentEvent.Package.Declared.WithVariant.asPanelContent(
     onlyStable: Boolean,
     isLoading: Boolean,
-) = listOf(
-    InfoPanelContent.PackageInfo.Declared.WithVariant(
-        moduleId = module.identity,
-        packageListId = packageListId,
-        tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview"),
-        title = declaredPackage.displayName,
-        subtitle = declaredPackage.coordinates,
-        icon = declaredPackage.icon,
-        type = declaredPackage.typeInfo,
-        licenses = declaredPackage.remoteInfo?.licenses?.asInfoPanelLicenseList() ?: emptyList(),
-        authors = declaredPackage.remoteInfo?.authors?.mapNotNull { it.name } ?: emptyList(),
-        description = declaredPackage.remoteInfo
-            ?.description
-            ?.sanitizeDescription(),
-        scm = declaredPackage.remoteInfo?.scm?.asInfoPanelScm(),
-        readmeUrl = declaredPackage.remoteInfo?.scm?.readme?.htmlUrl ?: declaredPackage.remoteInfo?.scm?.readmeUrl,
-        repositories = declaredPackage.remoteInfo?.repositories() ?: emptyList(),
-        latestVersion = declaredPackage.getLatestVersion(onlyStable)?.versionName,
-        declaredVersion = declaredPackage.declaredVersion
-            ?.versionName
-            ?: message("packagesearch.ui.missingVersion"),
-        declaredScope = declaredPackage.declaredScope
-            ?: message("packagesearch.ui.missingScope"),
-        availableVersions = declaredPackage.remoteInfo
-            ?.versions
-            ?.all
-            ?.filter { if (onlyStable) it.normalizedVersion.isStable else true }
-            ?.map { it.normalizedVersion.versionName }
-            ?: emptyList(),
-        availableScopes = module.variants.getValue(variantName).availableScopes,
-        isLoading = isLoading,
-        compatibleVariants = module.variants.keys.sorted() - variantName,
-        declaredVariant = variantName,
-        allowMissingScope = !module.dependencyMustHaveAScope,
-        variantTerminology = module.variantTerminology
-    ),
-    InfoPanelContent.Attributes.FromVariant(
-        variantName = variantName,
-        tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms"),
-        attributes = module.variants.getValue(variantName).attributes
+) = buildList {
+    add(
+        InfoPanelContent.PackageInfo.Declared.WithVariant(
+            moduleId = module.identity,
+            packageListId = packageListId,
+            tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview")),
+            title = declaredPackage.displayName,
+            subtitle = declaredPackage.coordinates,
+            icon = declaredPackage.icon,
+            type = declaredPackage.typeInfo,
+            licenses = declaredPackage.remoteInfo?.licenses?.asInfoPanelLicenseList() ?: emptyList(),
+            authors = declaredPackage.remoteInfo?.authors?.mapNotNull { it.name } ?: emptyList(),
+            description = declaredPackage.remoteInfo
+                ?.description
+                ?.sanitizeDescription(),
+            scm = declaredPackage.remoteInfo?.scm?.asInfoPanelScm(),
+            readmeUrl = declaredPackage.remoteInfo?.scm?.readme?.htmlUrl ?: declaredPackage.remoteInfo?.scm?.readmeUrl,
+            repositories = declaredPackage.remoteInfo?.repositories() ?: emptyList(),
+            latestVersion = declaredPackage.getLatestVersion(onlyStable)?.versionName,
+            declaredVersion = declaredPackage.declaredVersion
+                ?.versionName
+                ?: message("packagesearch.ui.missingVersion"),
+            declaredScope = declaredPackage.declaredScope
+                ?: message("packagesearch.ui.missingScope"),
+            availableVersions = declaredPackage.remoteInfo
+                ?.versions
+                ?.all
+                ?.filter { if (onlyStable) it.normalizedVersion.isStable else true }
+                ?.map { it.normalizedVersion.versionName }
+                ?: emptyList(),
+            availableScopes = module.variants.getValue(variantName).availableScopes,
+            isLoading = isLoading,
+            compatibleVariants = module.variants.keys.sorted() - variantName,
+            declaredVariant = variantName,
+            allowMissingScope = !module.dependencyMustHaveAScope,
+            variantTerminology = module.variantTerminology
+        )
     )
-)
+    addAttributesFromNames(declaredPackage.listKMPAttributesNames(onlyStable))
+}
 
 context(PackageSearchKnownRepositoriesContext)
 internal fun InfoPanelContentEvent.Package.Remote.WithVariants.asPanelContent(
+    onlyStable: Boolean,
     isLoading: Boolean,
-) = listOf(
-    InfoPanelContent.PackageInfo.Remote.WithVariant(
-        tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview"),
-        moduleId = module.identity,
-        packageListId = packageListId,
-        title = apiPackage.name,
-        subtitle = apiPackage.coordinates,
-        icon = apiPackage.icon,
-        type = apiPackage.typeInfo,
-        licenses = apiPackage.licenses?.asInfoPanelLicenseList() ?: emptyList(),
-        authors = apiPackage.authors.mapNotNull { it.name },
-        description = apiPackage.description?.sanitizeDescription(),
-        scm = apiPackage.scm?.asInfoPanelScm(),
-        readmeUrl = apiPackage.scm?.readme?.htmlUrl ?: apiPackage.scm?.readmeUrl,
-        primaryVariant = primaryVariantName,
-        additionalVariants = compatibleVariantNames.sorted() - primaryVariantName,
-        repositories = apiPackage.repositories(),
-        isLoading = isLoading,
-        isInstalledInPrimaryVariant = module.variants.getValue(primaryVariantName).declaredDependencies
-            .any { it.id == apiPackage.id }
-    ),
-    InfoPanelContent.Attributes.FromVariant(
-        tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms"),
-        variantName = primaryVariantName,
-        attributes = module.variants.getValue(primaryVariantName).attributes
-    )
-)
+) = buildList {
+    add(
+        InfoPanelContent.PackageInfo.Remote.WithVariant(
+            tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview")),
+            moduleId = module.identity,
+            packageListId = packageListId,
+            title = apiPackage.name,
+            subtitle = apiPackage.coordinates,
+            icon = apiPackage.icon,
+            type = apiPackage.typeInfo,
+            licenses = apiPackage.licenses?.asInfoPanelLicenseList() ?: emptyList(),
+            authors = apiPackage.authors.mapNotNull { it.name },
+            description = apiPackage.description?.sanitizeDescription(),
+            scm = apiPackage.scm?.asInfoPanelScm(),
+            readmeUrl = apiPackage.scm?.readme?.htmlUrl ?: apiPackage.scm?.readmeUrl,
+            primaryVariant = primaryVariantName,
+            additionalVariants = compatibleVariantNames.sorted() - primaryVariantName,
+            repositories = apiPackage.repositories(),
+            isLoading = isLoading,
+            isInstalledInPrimaryVariant = module.variants.getValue(primaryVariantName).declaredDependencies
+                .any { it.id == apiPackage.id }
+        ))
+    addAttributesFromNames(apiPackage.listKMPAttributesNames(onlyStable))
+}
 
 context(PackageSearchKnownRepositoriesContext)
 internal fun InfoPanelContentEvent.Package.Remote.Base.asPanelContent(
+    onlyStable: Boolean,
     isLoading: Boolean,
-) = listOf(
-    InfoPanelContent.PackageInfo.Remote.Base(
-        tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview"),
-        moduleId = module.identity,
-        packageListId = packageListId,
-        title = apiPackage.name,
-        subtitle = apiPackage.coordinates,
-        icon = apiPackage.icon,
-        type = apiPackage.typeInfo,
-        licenses = apiPackage.licenses?.asInfoPanelLicenseList() ?: emptyList(),
-        authors = apiPackage.authors.mapNotNull { it.name },
-        description = apiPackage.description?.sanitizeDescription(),
-        scm = apiPackage.scm?.asInfoPanelScm(),
-        readmeUrl = apiPackage.scm?.readme?.htmlUrl ?: apiPackage.scm?.readmeUrl,
-        repositories = apiPackage.repositories(),
-        isLoading = isLoading
+) = buildList {
+    add(
+        InfoPanelContent.PackageInfo.Remote.Base(
+            tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.overview")),
+            moduleId = module.identity,
+            packageListId = packageListId,
+            title = apiPackage.name,
+            subtitle = apiPackage.coordinates,
+            icon = apiPackage.icon,
+            type = apiPackage.typeInfo,
+            licenses = apiPackage.licenses?.asInfoPanelLicenseList() ?: emptyList(),
+            authors = apiPackage.authors.mapNotNull { it.name },
+            description = apiPackage.description?.sanitizeDescription(),
+            scm = apiPackage.scm?.asInfoPanelScm(),
+            readmeUrl = apiPackage.scm?.readme?.htmlUrl ?: apiPackage.scm?.readmeUrl,
+            repositories = apiPackage.repositories(),
+            isLoading = isLoading
+        )
     )
-)
+    addAttributesFromNames(apiPackage.listKMPAttributesNames(onlyStable))
+
+
+}
 
 internal fun InfoPanelContentEvent.Attributes.FromVariant.asPanelContent() = listOf(
-    InfoPanelContent.Attributes.FromVariant(
+    InfoPanelContent.Attributes.FromVariantHeader(
+        tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms")),
         variantName = variantName,
-        tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms"),
         attributes = attributes,
     )
 )
 
 internal fun InfoPanelContentEvent.Attributes.FromSearch.asPanelContent() = listOf(
-    InfoPanelContent.Attributes.FromSearch(
-        tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.attributes"),
+    InfoPanelContent.Attributes.FromSearchHeader(
+        tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.packages.details.info.attributes")),
         defaultSourceSet = defaultVariant,
         additionalSourceSets = additionalVariants,
         attributes = attributes,
     )
 )
+
+private fun MutableList<InfoPanelContent>.addAttributesFromNames(
+    attributesNames: Set<String>,
+) {
+    if (attributesNames.isNotEmpty()) add(
+        InfoPanelContent.Attributes.FromPackage(
+            tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms")),
+            attributes = buildAttributesFromRawStrings(attributesNames)
+        )
+    )
+}

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/HeaderAttributesTab.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -59,7 +58,7 @@ private fun HeaderAttributesTabImpl(
     val attributeGlobalPositionMap = remember { mutableMapOf<Int, Int>() }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.padding(12.dp)) {
-        if (content is InfoPanelContent.Attributes.FromSearch) {
+        if (content is InfoPanelContent.Attributes.FromSearchHeader) {
             Text(
                 text = contentTitle,
                 fontSize = 14.sp,
@@ -76,7 +75,7 @@ private fun HeaderAttributesTabImpl(
             }
         }
 
-        if (content is InfoPanelContent.Attributes.FromSearch) {
+        if (content is InfoPanelContent.Attributes.FromSearchHeader) {
             SourceSetsList(content, sourceSetString)
         }
 
@@ -86,8 +85,8 @@ private fun HeaderAttributesTabImpl(
 
 
 @Composable
-private fun ColumnScope.SourceSetsList(
-    content: InfoPanelContent.Attributes.FromSearch,
+private fun SourceSetsList(
+    content: InfoPanelContent.Attributes.FromSearchHeader,
     title: String,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -175,7 +174,7 @@ fun AttributeItem(modifier: Modifier = Modifier, attributeName: String, nestedAt
 //@Composable
 //private fun HeaderAttributesPreviewTab() {
 //    val activeTabMock = InfoPanelContent.Attributes.FromVariant(
-//        tabTitle = "FromVariant",
+//        tabTitleData = "FromVariant",
 //        variantName = "jvm",
 //        attributes = generateAttributesMock()
 //    )

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/side/PackageSearchInfoPanel.kt
@@ -38,7 +38,7 @@ fun PackageSearchInfoPanel(
     val tabs by viewModel.tabs.collectAsState()
     val activeTabTitle by viewModel.activeTabTitleFlow.collectAsState()
     // if you use `by derivedStateOf`, the then will fail
-    val activeTab = derivedStateOf { tabs.firstOrNull { it.tabTitle == activeTabTitle } }.value
+    val activeTab = derivedStateOf { tabs.firstOrNull { it.tabTitleData.tabTitle == activeTabTitle } }.value
     when {
         tabs.isEmpty() || activeTab == null -> NoTabsAvailable()
         else -> Column(modifier = Modifier.fillMaxSize()) {
@@ -46,14 +46,14 @@ fun PackageSearchInfoPanel(
                 modifier = Modifier.fillMaxWidth(),
                 tabs = tabs.map { infoPanelContent ->
                     TabData.Default(
-                        selected = activeTabTitle == infoPanelContent.tabTitle,
+                        selected = activeTabTitle == infoPanelContent.tabTitleData.tabTitle,
                         closable = false,
                         content = { tabState ->
                             Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
-                                SimpleTabContent(infoPanelContent.tabTitle, tabState)
+                                SimpleTabContent(infoPanelContent.tabTitleData.tabTitle, tabState)
                             }
                         },
-                        onClick = { viewModel.setActiveTabTitle(infoPanelContent.tabTitle) },
+                        onClick = { viewModel.setActiveTabTitle(infoPanelContent.tabTitleData.tabTitle) },
                     )
                 }
             )
@@ -72,14 +72,19 @@ fun PackageSearchInfoPanel(
                             )
                         }
 
-                        is InfoPanelContent.Attributes.FromVariant -> {
+                        is InfoPanelContent.Attributes.FromVariantHeader -> {
                             HeaderAttributesTab(content = activeTab, scrollState = viewModel.scrollState)
 
                         }
 
-                        is InfoPanelContent.Attributes.FromSearch -> {
+                        is InfoPanelContent.Attributes.FromSearchHeader -> {
                             HeaderAttributesTab(content = activeTab, scrollState = viewModel.scrollState)
                         }
+
+                        is InfoPanelContent.Attributes.FromPackage -> HeaderAttributesTab(
+                            content = activeTab,
+                            scrollState = viewModel.scrollState
+                        )
                     }
                 }
                 VerticalScrollbar(

--- a/plugin/src/main/resources/messages/packageSearchBundle.properties
+++ b/plugin/src/main/resources/messages/packageSearchBundle.properties
@@ -225,6 +225,6 @@ packagesearch.toolwindow.loading.dumbMode=Project is initializing...
 packagesearch.ui.tree.tooltips.expand=Expand all
 packagesearch.ui.tree.tooltips.collapse=Collapse all
 packagesearch.ui.toolwindow.sidepanel.platformsList=Platforms:
-packagesearch.ui.toolwindow.sidepanel.platforms=Platforms
+packagesearch.ui.toolwindow.sidepanel.platforms=Kotlin Platform
 packagesearch.ui.toolwindow.sidepanel.searchResultSupport=Search results that support:
 packagesearch.ui.toolwindow.sidepanel.searchResultSupport.sourceSets=Source Sets:


### PR DESCRIPTION
Fixed KMP-Platforms and attribute information for InfoPanel Fixed warning log readability in KMP-modifier module Simplified the KMP-Attributes computation for KMP packages (remote or declared) Clarify ui events by using more accurate names
Clarified tabs in InfoPanel, by changing tab name from Platforms to KMP-Platforms Refactor code for readability in PackageSearchInfoPanel

(cherry picked from commit fac3e91e0c0b89338228e96938f338c6b59908bf)