### PR TITLE
Refactor MavenImportListener in MavenUtils

### DIFF
--- a/plugin/maven/src/main/kotlin/com/jetbrains/packagesearch/plugin/maven/MavenUtils.kt
+++ b/plugin/maven/src/main/kotlin/com/jetbrains/packagesearch/plugin/maven/MavenUtils.kt
@@ -40,8 +40,6 @@ import org.jetbrains.idea.maven.project.MavenProjectsManager
 import org.jetbrains.packagesearch.api.v3.ApiPackage
 import org.jetbrains.packagesearch.api.v3.ApiRepository
 import org.jetbrains.packagesearch.api.v3.search.buildPackageTypes
-import org.jetbrains.packagesearch.api.v3.search.javaApi
-import org.jetbrains.packagesearch.api.v3.search.javaRuntime
 import org.jetbrains.packagesearch.api.v3.search.jvmMavenPackages
 import org.jetbrains.packagesearch.maven.POM_XML_NAMESPACE
 import org.jetbrains.packagesearch.maven.ProjectObjectModel
@@ -63,10 +61,16 @@ val commonScopes = listOf("compile", "provided", "runtime", "test", "system", "i
 
 val Project.mavenImportFlow
     get() = messageBus.flow(MavenImportListener.TOPIC) {
-        MavenImportListener { _, _ ->
-            trySend(Unit)
+        object : MavenImportListener {
+            override fun importFinished(
+                importedProjects: MutableCollection<MavenProject>,
+                newModules: MutableList<Module>,
+            ) {
+                trySend(Unit)
+            }
         }
     }
+
 context(ProjectContext)
 fun getModuleChangesFlow(pomPath: Path): Flow<Unit> = merge(
     watchExternalFileChanges(mavenSettingsFilePath),


### PR DESCRIPTION
The importFinished method in MavenImportListener has been modified to receive two additional parameters: importedProjects and newModules. Additionally, unnecessary import lines for javaApi and javaRuntime were removed from MavenUtils.kt. This refinement provides more information during the import finish event for further handling.

(cherry picked from commit d62be21d0e67d86c0369020cc9e225cc4ab50ee5)