### PR TITLE
Implement error handling for search, added log debugging for search caches.

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
@@ -36,6 +36,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredPackage
 import com.jetbrains.packagesearch.plugin.core.services.PackageSearchProjectCachesService
 import java.nio.file.Path
 import kotlin.contracts.contract
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -309,3 +310,5 @@ class ProjectDataImportListenerAdapter(private val project: Project) : ProjectDa
         project.service<State>().value = false
     }
 }
+
+fun <T> Result<T>.suspendSafe() = onFailure { if (it is CancellationException) throw it }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListBuilder.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListBuilder.kt
@@ -306,17 +306,27 @@ class PackageListBuilder(
         attributes: List<String> = emptyList(),
         additionalContent: PackageListItem.Header.AdditionalContent.VariantsText? = null,
     ) {
+        val headerState = when (headerCollapsedStates[headerId]) {
+            TargetState.OPEN -> PackageListItem.Header.State.OPEN
+            else -> PackageListItem.Header.State.CLOSED
+        }
         addHeader(
             title = PackageSearchBundle.message("packagesearch.ui.toolwindow.tab.packages.searchResults"),
             id = headerId,
-            state = when (headerCollapsedStates[headerId]) {
-                TargetState.OPEN -> PackageListItem.Header.State.OPEN
-                else -> PackageListItem.Header.State.CLOSED
-            },
+            state = headerState,
             attributes = attributes,
             additionalContent = additionalContent,
         )
-        items.add(PackageListItem.SearchError(id = PackageListItem.SearchError.Id(headerId.moduleIdentity, headerId)))
+        if (headerState == PackageListItem.Header.State.OPEN) {
+            items.add(
+                PackageListItem.SearchError(
+                    id = PackageListItem.SearchError.Id(
+                        headerId.moduleIdentity,
+                        headerId
+                    )
+                )
+            )
+        }
     }
 
     private fun addFromSearchQueryWithVariants(

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItem.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItem.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 
 sealed interface PackageListItem {
 
-    val title: String
     val id: Id
 
     @Serializable
@@ -15,7 +14,7 @@ sealed interface PackageListItem {
     }
 
     data class Header(
-        override val title: String,
+        val title: String,
         override val id: Id,
         val state: State,
         val attributes: List<String> = emptyList(),
@@ -39,6 +38,7 @@ sealed interface PackageListItem {
             sealed interface Declared : Id {
                 @Serializable
                 data class Base(override val moduleIdentity: PackageSearchModule.Identity) : Declared
+
                 @Serializable
                 data class WithVariant(
                     override val moduleIdentity: PackageSearchModule.Identity,
@@ -49,8 +49,10 @@ sealed interface PackageListItem {
 
             @Serializable
             sealed interface Remote : Id {
+
                 @Serializable
                 data class Base(override val moduleIdentity: PackageSearchModule.Identity) : Remote
+
                 @Serializable
                 data class WithVariant(
                     override val moduleIdentity: PackageSearchModule.Identity,
@@ -62,6 +64,8 @@ sealed interface PackageListItem {
     }
 
     sealed interface Package : PackageListItem {
+
+        val title: String
 
         @Serializable
         sealed interface Id : PackageListItem.Id {
@@ -121,7 +125,7 @@ sealed interface PackageListItem {
                     override val moduleIdentity: PackageSearchModule.Identity,
                     override val packageId: String,
                     val headerId: Header.Id.Remote.Base,
-                    ) : Remote.Id
+                ) : Remote.Id
             }
 
             data class WithVariant(
@@ -143,4 +147,14 @@ sealed interface PackageListItem {
             }
         }
     }
+
+    data class SearchError(override val id: Id) : PackageListItem {
+
+        @Serializable
+        data class Id(
+            override val moduleIdentity: PackageSearchModule.Identity,
+            val parentHeaderId: Header.Id,
+        ) : PackageListItem.Id
+    }
+
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
@@ -114,4 +114,9 @@ sealed interface PackageListItemEvent {
         data class GoToSource(override val eventId: PackageListItem.Package.Declared.Id) : OnPackageAction
 
     }
+
+    @Serializable
+    data class OnRetryPackageSearch(
+        override val eventId: PackageListItem.SearchError.Id,
+    ) : PackageListItemEvent
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/PackageSearchPackageList.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/PackageSearchPackageList.kt
@@ -104,8 +104,26 @@ fun PackageSearchPackageList(
                         onPopupDismissRequest = { openPopupId = null }
                     )
                 }
+
+                is PackageListItem.SearchError -> item(key = item.id, contentType = item.contentType()) {
+                    SearchErrorItem(
+                        onLinkClick = { onPackageEvent(PackageListItemEvent.OnRetryPackageSearch(item.id)) }
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+fun SearchErrorItem(onLinkClick: () -> Unit) {
+    Column(
+        Modifier.fillMaxSize().padding(20.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(message("packagesearch.ui.toolwindow.tab.packages.searchResults.error"))
+        Link(message("packagesearch.ui.toolwindow.tab.packages.searchResults.error.retry"), onClick = onLinkClick)
     }
 }
 
@@ -405,6 +423,7 @@ private fun PackageListItem.contentType() = when (this) {
     is PackageListItem.Header -> "header"
     is PackageListItem.Package.Declared -> "declared.package"
     is PackageListItem.Package.Remote -> "remote.package"
+    is PackageListItem.SearchError -> "search.error"
 }
 
 @Composable

--- a/plugin/src/main/resources/messages/packageSearchBundle.properties
+++ b/plugin/src/main/resources/messages/packageSearchBundle.properties
@@ -195,6 +195,8 @@ packagesearch.ui.toolwindow.packages.sort.by=Sort by:
 
 packagesearch.ui.toolwindow.tab.packages.installedPackages.addedIn=Added in {0}
 packagesearch.ui.toolwindow.tab.packages.searchResults=Search Results
+packagesearch.ui.toolwindow.tab.packages.searchResults.error=An error occurred while searching for dependencies.
+packagesearch.ui.toolwindow.tab.packages.searchResults.error.retry=Try again
 packagesearch.ui.toolwindow.tab.packages.selectedPackage=Selected dependency
 packagesearch.ui.toolwindow.tab.packages.title=Manage
 packagesearch.ui.toolwindow.tab.repositories.no.repositories.configured=There are no repositories configured in the current project


### PR DESCRIPTION
Added new functionality to handle search errors during package search, allowing users to retry the search. Included visual error representation in the UI with a retry link. The search can now also be retried programmatically if it fails.

In this video, the results that shows up are cached.

<video src='https://github.com/JetBrains/package-search-intellij-plugin/assets/10994011/098b4ff1-eceb-4a4b-b51c-d1af97f55422'/>

