### PR TITLE
241-Platform side panel badge duplicate and wrong source-sets for KMP headers 

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchModuleVariant.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchModuleVariant.kt
@@ -33,3 +33,4 @@ interface PackageSearchModuleVariant : PackageSearchDependencyManager {
     fun isCompatible(dependency: ApiPackage, version: ApiPackageVersion): Boolean
 
 }
+

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
@@ -6,7 +6,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredPackage
 import com.jetbrains.packagesearch.plugin.core.data.listKMPAttributesNames
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchKnownRepositoriesContext
 import com.jetbrains.packagesearch.plugin.core.utils.icon
-import com.jetbrains.packagesearch.plugin.gradle.buildAttributesFromRawStrings
+import com.jetbrains.packagesearch.plugin.gradle.parseAttributesFromRawStrings
 import com.jetbrains.packagesearch.plugin.ui.model.getLatestVersion
 import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
 import org.jetbrains.packagesearch.api.v3.ApiPackage
@@ -218,7 +218,7 @@ private fun MutableList<InfoPanelContent>.addAttributesFromNames(
     if (attributesNames.isNotEmpty()) add(
         InfoPanelContent.Attributes.FromPackage(
             tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms")),
-            attributes = buildAttributesFromRawStrings(attributesNames)
+            attributes = attributesNames.parseAttributesFromRawStrings()
         )
     )
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
@@ -28,9 +28,9 @@ sealed interface PackageListItemEvent {
                 val variantName: String,
             ) : OnHeaderAttributesClick
             @Serializable
-            data class SearchHeaderAttributesClick(
-                override val eventId: PackageListItem.Header.Id.Remote,
-                val attributesNames: List<String>
+            data class SearchHeaderWithVariantsAttributesClick(
+                override val eventId: PackageListItem.Header.Id.Remote.WithVariant,
+                val attributesNames: List<String>,
             ) : OnHeaderAttributesClick
 
         }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
@@ -616,19 +616,23 @@ class PackageListViewModel(
                 infoPanelViewModel.setDeclaredHeaderAttributes(event.variantName, attributes = attributes)
             }
 
-            is PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderAttributesClick -> {
-                val attributes = module
-                    .variants
-                    .map { it.value.attributes }
-                    .flatten()
-                    .filter { it.value in event.attributesNames }
-                    .distinct()
+            is PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderWithVariantsAttributesClick -> {
 
-                val variants = module.variants.values.map { it.name } - module.mainVariantName
+                val variants = event.eventId
+                    .compatibleVariantNames
+                    .mapNotNull { module.variants[it] }
+
+                val defaultVariant = variants.firstOrNull { it.isPrimary }?.name
+                    ?: variants.firstOrNull()?.name
+                    ?: return
+
+                val attributes = variants.firstOrNull()
+                    ?.attributes
+                    ?: return
 
                 infoPanelViewModel.setSearchHeaderAttributes(
-                    defaultVariant = module.mainVariantName,
-                    additionalVariants = variants,
+                    defaultVariant = defaultVariant,
+                    additionalVariants = variants.map { it.name } - defaultVariant,
                     attributes = attributes
                 )
             }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/items/PackageGroupHeader.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/items/PackageGroupHeader.kt
@@ -104,11 +104,12 @@ fun PackageListHeader(
                         .onClick {
                             val event =
                                 when (content.id) {
-                                    is PackageListItem.Header.Id.Declared.Base -> return@onClick
-                                    is PackageListItem.Header.Id.Remote -> PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderAttributesClick(
+                                    is PackageListItem.Header.Id.Declared.Base, is PackageListItem.Header.Id.Remote.Base -> return@onClick
+                                    is PackageListItem.Header.Id.Remote.WithVariant -> PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderWithVariantsAttributesClick(
                                         eventId = content.id,
                                         attributesNames = content.attributes
                                     )
+
                                     is PackageListItem.Header.Id.Declared.WithVariant -> PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.DeclaredHeaderAttributesClick(
                                         eventId = content.id,
                                         variantName = content.title,


### PR DESCRIPTION
Fix [PKGS-1371](https://youtrack.jetbrains.com/issue/PKGS-1371/Platform-side-panel-badge-duplicates) - Platform side panel badge duplicate and wrong source-sets
<img width="376" alt="image" src="https://github.com/JetBrains/package-search-intellij-plugin/assets/36624359/7b31375f-ebc8-4947-b706-77a910add3e2">
