### PR TITLE
232-Platform side panel badge duplicate and wrong source-sets for KMP headers

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchModuleVariant.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/data/PackageSearchModuleVariant.kt
@@ -33,3 +33,4 @@ interface PackageSearchModuleVariant : PackageSearchDependencyManager {
     fun isCompatible(dependency: ApiPackage, version: ApiPackageVersion): Boolean
 
 }
+

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/asPanelContent.kt
@@ -6,7 +6,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredPackage
 import com.jetbrains.packagesearch.plugin.core.data.listKMPAttributesNames
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchKnownRepositoriesContext
 import com.jetbrains.packagesearch.plugin.core.utils.icon
-import com.jetbrains.packagesearch.plugin.gradle.buildAttributesFromRawStrings
+import com.jetbrains.packagesearch.plugin.gradle.parseAttributesFromRawStrings
 import com.jetbrains.packagesearch.plugin.ui.model.getLatestVersion
 import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
 import org.jetbrains.packagesearch.api.v3.ApiPackage
@@ -218,7 +218,7 @@ private fun MutableList<InfoPanelContent>.addAttributesFromNames(
     if (attributesNames.isNotEmpty()) add(
         InfoPanelContent.Attributes.FromPackage(
             tabTitleData = InfoPanelContent.TabTitleData(tabTitle = message("packagesearch.ui.toolwindow.sidepanel.platforms")),
-            attributes = buildAttributesFromRawStrings(attributesNames)
+            attributes = attributesNames.parseAttributesFromRawStrings()
         )
     )
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItemEvent.kt
@@ -29,8 +29,8 @@ sealed interface PackageListItemEvent {
             ) : OnHeaderAttributesClick
 
             @Serializable
-            data class SearchHeaderAttributesClick(
-                override val eventId: PackageListItem.Header.Id.Remote,
+            data class SearchHeaderWithVariantsAttributesClick(
+                override val eventId: PackageListItem.Header.Id.Remote.WithVariant,
                 val attributesNames: List<String>,
             ) : OnHeaderAttributesClick
 

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
@@ -629,19 +629,23 @@ class PackageListViewModel(private val project: Project) : Disposable {
                 infoPanelViewModel.setDeclaredHeaderAttributes(event.variantName, attributes = attributes)
             }
 
-            is PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderAttributesClick -> {
-                val attributes = module
-                    .variants
-                    .map { it.value.attributes }
-                    .flatten()
-                    .filter { it.value in event.attributesNames }
-                    .distinct()
+            is PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderWithVariantsAttributesClick -> {
 
-                val variants = module.variants.values.map { it.name } - module.mainVariantName
+                val variants = event.eventId
+                    .compatibleVariantNames
+                    .mapNotNull { module.variants[it] }
+
+                val defaultVariant = variants.firstOrNull { it.isPrimary }?.name
+                    ?: variants.firstOrNull()?.name
+                    ?: return
+
+                val attributes = variants.firstOrNull()
+                    ?.attributes
+                    ?: return
 
                 infoPanelViewModel.setSearchHeaderAttributes(
-                    defaultVariant = module.mainVariantName,
-                    additionalVariants = variants,
+                    defaultVariant = defaultVariant,
+                    additionalVariants = variants.map { it.name } - defaultVariant,
                     attributes = attributes
                 )
             }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/items/PackageGroupHeader.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/panels/packages/items/PackageGroupHeader.kt
@@ -104,8 +104,8 @@ fun PackageListHeader(
                         .onClick {
                             val event =
                                 when (content.id) {
-                                    is PackageListItem.Header.Id.Declared.Base -> return@onClick
-                                    is PackageListItem.Header.Id.Remote -> PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderAttributesClick(
+                                    is PackageListItem.Header.Id.Declared.Base, is PackageListItem.Header.Id.Remote.Base -> return@onClick
+                                    is PackageListItem.Header.Id.Remote.WithVariant -> PackageListItemEvent.InfoPanelEvent.OnHeaderAttributesClick.SearchHeaderWithVariantsAttributesClick(
                                         eventId = content.id,
                                         attributesNames = content.attributes
                                     )


### PR DESCRIPTION
cherry-pick for #55 
This commit improves the handling of attributes within the JetBrains package search plugin. Changes include renaming the `buildAttributesFromRawStrings` function to `parseAttributesFromRawStrings`, and refactoring its implementation for better readability. Additionally, a new `mergeAttributes` function has been added to handle cases where attributes need to be combined, improving code reusability and clarity.