### PR TITLE
241 - Fix PKGS-1379 Remove Gradle tooling classes from main plugin jar

### DIFF
--- a/plugin/gradle/build.gradle.kts
+++ b/plugin/gradle/build.gradle.kts
@@ -25,7 +25,7 @@ intellij {
 }
 
 dependencies {
-    implementation(projects.plugin.gradle.tooling)
+    compileOnly(projects.plugin.gradle.tooling)
     sourceElements(projects.plugin.gradle.tooling)
     api(projects.plugin.core)
     sourceElements(projects.plugin.core)

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
@@ -10,9 +10,7 @@ import com.jetbrains.packagesearch.plugin.gradle.GradleDependencyModel
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import org.jetbrains.kotlin.psi.psiUtil.parents
-import org.jetbrains.plugins.gradle.execution.build.CachedModuleDataFinder
 import org.jetbrains.plugins.gradle.util.GradleConstants
-import org.jetbrains.plugins.gradle.util.gradleIdentityPathOrNull
 
 val Module.isGradleSourceSet: Boolean
     get() {
@@ -20,11 +18,11 @@ val Module.isGradleSourceSet: Boolean
         return ExternalSystemApiUtil.getExternalModuleType(this) == GradleConstants.GRADLE_SOURCE_SET_MODULE_TYPE_KEY
     }
 
-val Module.gradleIdentityPathOrNull: String?
-    get() = CachedModuleDataFinder.getInstance(project)
-        .findMainModuleData(this)
-        ?.data
-        ?.gradleIdentityPathOrNull
+//val Module.gradleIdentityPathOrNull: String?
+//    get() = CachedModuleDataFinder.getInstance(project)
+//        .findMainModuleData(this)
+//        ?.data
+//        ?.gradleIdentityPathOrNull
 
 suspend fun Project.awaitExternalSystemInitialization() = suspendCoroutine {
     ExternalProjectsManager.getInstance(this@awaitExternalSystemInitialization)


### PR DESCRIPTION
Fix [PKGS-1379](https://youtrack.jetbrains.com/issue/PKGS-1379/Gradle-failure-Cannot-cache-packageSearch.jar-Unsupported-class-file-major-version-61)

remove /tooling from build\..\plugin\gradle to avoid wrong class usage in Gradle