### PR TITLE
Add change notes to plugin XML

### DIFF
--- a/.github/workflows/publish-release.yml.disabled
+++ b/.github/workflows/publish-release.yml.disabled
@@ -2,7 +2,7 @@ name: Publish to Marketplace
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish:
@@ -25,3 +25,4 @@ jobs:
           GRADLE_ENTERPRISE_KEY: ${{ secrets.GRADLE_ENTERPRISE_KEY }}
           MAVEN_SPACE_PASSWORD: ${{ secrets.MAVEN_SPACE_PASSWORD }}
           MAVEN_SPACE_USERNAME: ${{ secrets.MAVEN_SPACE_USERNAME }}
+          CHANGE_NOTES: ${{ github.event.release.body }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,4 +30,5 @@ dependencies {
     implementation(packageSearchCatalog.kotlinx.serialization.json)
     implementation("com.squareup:kotlinpoet:1.14.2")
     implementation("io.github.pdvrieze.xmlutil:serialization:0.86.2")
+    implementation("com.vladsch.flexmark:flexmark-all:0.64.8")
 }


### PR DESCRIPTION
The `build.gradle.kts` file is updated to parse change notes from an environment variable and add it to the plugin XML. This change helps to automate the process of updating change notes. The GitHub workflow file has also been updated to pass the release body as change notes for each build.