### PR TITLE
Disable packages download UI state in ToolWindowViewModel

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
@@ -73,10 +73,11 @@ class ToolWindowViewModel(project: Project, private val viewModelScope: Coroutin
             isProjectSyncing -> PackageSearchToolWindowState.Loading(
                 message = easterEggMessage ?: message("packagesearch.toolwindow.loading.syncing")
             )
-
-            packagesBeingDownloaded -> PackageSearchToolWindowState.Loading(
-                message = easterEggMessage ?: message("packagesearch.toolwindow.loading.downloading")
-            )
+// Commented to mitigate PKGS-1389 "dowloading packages" UI does not reflect if packages are really being downloaded or not
+// https://youtrack.jetbrains.com/issue/PKGS-1389
+//            packagesBeingDownloaded -> PackageSearchToolWindowState.Loading(
+//                message = easterEggMessage ?: message("packagesearch.toolwindow.loading.downloading")
+//            )
 
             else -> PackageSearchToolWindowState.NoModules
         }


### PR DESCRIPTION
The handling for showing packages being downloaded in the ToolWindowViewModel has been deactivated. This was done to mitigate PKGS-1389 issue where the UI did not accurately reflect if packages were downloading or not.