### PR TITLE
241 - Fix IDEA-347713 Package Search Plugin high CPU use

### DIFF
--- a/nitrite/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/nitrite/coroutines/CoroutineObjectRepository.kt
+++ b/nitrite/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/nitrite/coroutines/CoroutineObjectRepository.kt
@@ -3,6 +3,7 @@ package com.jetbrains.packagesearch.plugin.core.nitrite.coroutines
 import com.jetbrains.packagesearch.plugin.core.nitrite.DocumentPathBuilder
 import com.jetbrains.packagesearch.plugin.core.nitrite.asKotlin
 import com.jetbrains.packagesearch.plugin.core.nitrite.serialization.NitriteDocumentFormat
+import java.io.Closeable
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -35,7 +36,7 @@ class CoroutineObjectRepository<T : Any> @InternalAPI constructor(
     val type: KType,
     private val documentFormat: NitriteDocumentFormat,
     override val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : CoroutineWrapper() {
+) : CoroutineWrapper(), Closeable by synchronous {
 
     data class Change<T>(val changeType: ChangeType, val changedItems: Flow<T>)
     data class Item<T>(val changeTimestamp: Instant, val changeType: ChangeType, val item: T)

--- a/plugin/core/build.gradle.kts
+++ b/plugin/core/build.gradle.kts
@@ -52,7 +52,7 @@ tasks {
         pluginId = pkgsPluginId
         outputDir = generatedDir
         packageName = "com.jetbrains.packagesearch.plugin.core"
-        databaseVersion = 1
+        databaseVersion = 2
     }
     sourcesJar {
         dependsOn(generatePluginDataSources)

--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/extensions/Contexts.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/extensions/Contexts.kt
@@ -23,10 +23,7 @@ interface PackageSearchApiPackagesContext {
 }
 
 interface PackageSearchModuleBuilderContext :
-    ProjectContext, PackageSearchKnownRepositoriesContext, PackageSearchApiPackagesContext {
-        val projectCaches: CoroutineNitrite
-        val applicationCaches: CoroutineNitrite
-    }
+    ProjectContext, PackageSearchKnownRepositoriesContext, PackageSearchApiPackagesContext
 
 interface ProjectContext {
     val project: Project

--- a/plugin/gradle/base/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleProvider.kt
+++ b/plugin/gradle/base/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleProvider.kt
@@ -33,7 +33,9 @@ class GradleModuleProvider : AbstractGradleModuleProvider() {
             val configurationNames = model.configurations
                 .filter { it.canBeDeclared }
                 .map { it.name }
-            val declaredDependencies = module.getDeclaredDependencies()
+            val declaredDependencies = model.buildFilePath
+                ?.let { module.getDeclaredDependencies(it) }
+                ?: emptyList()
             val packageSearchGradleModule = PackageSearchGradleModule(
                 name = model.projectName,
                 identity = PackageSearchModule.Identity(

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleDependencyModel.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleDependencyModel.kt
@@ -1,39 +1,16 @@
 package com.jetbrains.packagesearch.plugin.gradle
 
 import com.jetbrains.packagesearch.plugin.core.extensions.DependencyDeclarationIndexes
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class GradleDependencyModel(
     val groupId: String,
     val artifactId: String,
     val version: String?,
     val configuration: String,
     val indexes: DependencyDeclarationIndexes,
-) {
+)
 
-    val packageId
-        get() = "maven:$groupId:$artifactId"
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as GradleDependencyModel
-
-        if (groupId != other.groupId) return false
-        if (artifactId != other.artifactId) return false
-        if (version != other.version) return false
-        if (configuration != other.configuration) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = groupId.hashCode()
-        result = 31 * result + artifactId.hashCode()
-        result = 31 * result + (version?.hashCode() ?: 0)
-        result = 31 * result + configuration.hashCode()
-        return result
-    }
-
-
-}
+val GradleDependencyModel.packageId
+    get() = "maven:$groupId:$artifactId"

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchProjectService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchProjectService.kt
@@ -18,20 +18,21 @@ import com.jetbrains.packagesearch.plugin.core.utils.replayOn
 import com.jetbrains.packagesearch.plugin.core.utils.toolWindowOpenedFlow
 import com.jetbrains.packagesearch.plugin.fus.PackageSearchFUSEvent
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchApplicationCachesService
-import com.jetbrains.packagesearch.plugin.utils.PackageSearchFUSService
 import com.jetbrains.packagesearch.plugin.utils.WindowedModuleBuilderContext
+import com.jetbrains.packagesearch.plugin.utils.drop
 import com.jetbrains.packagesearch.plugin.utils.filterNotNullKeys
 import com.jetbrains.packagesearch.plugin.utils.logDebug
 import com.jetbrains.packagesearch.plugin.utils.logFUSEvent
 import com.jetbrains.packagesearch.plugin.utils.logWarn
 import com.jetbrains.packagesearch.plugin.utils.nativeModulesFlow
 import com.jetbrains.packagesearch.plugin.utils.startWithNull
+import com.jetbrains.packagesearch.plugin.utils.throttle
 import com.jetbrains.packagesearch.plugin.utils.timer
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asFlow
@@ -43,7 +44,6 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flatMapMerge
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -93,8 +93,6 @@ class PackageSearchProjectService(
         knownRepositoriesGetter = { knownRepositories },
         packagesCache = IntelliJApplication.PackageSearchApplicationCachesService.apiPackageCache,
         coroutineScope = coroutineScope,
-        projectCaches = project.PackageSearchProjectCachesService.cache,
-        applicationCaches = IntelliJApplication.PackageSearchApplicationCachesService.cache,
     )
 
     val packagesBeingDownloadedFlow = context.getLoadingFLow()
@@ -120,10 +118,7 @@ class PackageSearchProjectService(
             .debounce(1.seconds)
             .distinctUntilChanged()
 
-    private val restartFlow = restartChannel.consumeAsFlow()
-        .shareIn(coroutineScope, SharingStarted.Eagerly, 0)
-
-    val modulesStateFlow = restartFlow
+    val modulesStateFlow = restartChannel.consumeAsFlow()
         .onStart { emit(Unit) }
         .flatMapLatest { moduleProvidersList }
         .retry(5)
@@ -164,7 +159,9 @@ class PackageSearchProjectService(
                     else -> emptyFlow()
                 }
             }
+            .distinctUntilChanged()
             .filter { it }
+            .throttle(30.minutes)
             .onEach { restart() }
             .retry {
                 logWarn("${this::class.simpleName}#isOnlineFlow", throwable = it)
@@ -192,16 +189,5 @@ class PackageSearchProjectService(
             .launchIn(coroutineScope)
     }
 
-}
-
-private fun <T> Flow<T>.drop(count: Int, function: (T) -> Boolean) = flow {
-    var current = 0
-    collect {
-        if (current < count && function(it)) {
-            current++
-        } else {
-            emit(it)
-        }
-    }
 }
 

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Utils.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Utils.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.ModuleListener
 import com.intellij.openapi.project.Project
+import com.intellij.platform.util.coroutines.flow.throttle
 import com.intellij.util.Function
 import com.jetbrains.packagesearch.plugin.core.utils.FlowWithInitialValue
 import com.jetbrains.packagesearch.plugin.core.utils.flow
@@ -116,5 +117,19 @@ internal fun <T> timer(interval: Duration, generate: suspend () -> T) = flow {
     while (true) {
         emit(generate())
         delay(interval)
+    }
+}
+
+fun <T> Flow<T>.throttle(timeMs: Duration) =
+    throttle(timeMs.inWholeMilliseconds)
+
+fun <T> Flow<T>.drop(count: Int, function: (T) -> Boolean) = flow {
+    var current = 0
+    collect {
+        if (current < count && function(it)) {
+            current++
+        } else {
+            emit(it)
+        }
     }
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/WindowedModuleBuilderContext.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/WindowedModuleBuilderContext.kt
@@ -39,8 +39,6 @@ class WindowedModuleBuilderContext(
     private val knownRepositoriesGetter: () -> Map<String, ApiRepository>,
     private val packagesCache: PackageSearchApi,
     override val coroutineScope: CoroutineScope,
-    override val projectCaches: CoroutineNitrite,
-    override val applicationCaches: CoroutineNitrite,
 ) : PackageSearchModuleBuilderContext {
 
     override val knownRepositories: Map<String, ApiRepository>


### PR DESCRIPTION
This update modifies the caching system and retrieval of modules in Gradle projects. It revamps the caching of declared dependencies by associating them with their SHA hash of the respective build file, and storing them in the local caches.