### PR TITLE
232 - Fix IDEA-347713 Package Search Plugin high CPU use

### DIFF
--- a/nitrite/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/nitrite/coroutines/CoroutineObjectRepository.kt
+++ b/nitrite/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/nitrite/coroutines/CoroutineObjectRepository.kt
@@ -3,6 +3,7 @@ package com.jetbrains.packagesearch.plugin.core.nitrite.coroutines
 import com.jetbrains.packagesearch.plugin.core.nitrite.DocumentPathBuilder
 import com.jetbrains.packagesearch.plugin.core.nitrite.asKotlin
 import com.jetbrains.packagesearch.plugin.core.nitrite.serialization.NitriteDocumentFormat
+import java.io.Closeable
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlinx.coroutines.CoroutineDispatcher
@@ -35,7 +36,7 @@ class CoroutineObjectRepository<T : Any> @InternalAPI constructor(
     val type: KType,
     private val documentFormat: NitriteDocumentFormat,
     override val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : CoroutineWrapper() {
+) : CoroutineWrapper(), Closeable by synchronous {
 
     data class Change<T>(val changeType: ChangeType, val changedItems: Flow<T>)
     data class Item<T>(val changeTimestamp: Instant, val changeType: ChangeType, val item: T)

--- a/plugin/core/build.gradle.kts
+++ b/plugin/core/build.gradle.kts
@@ -52,7 +52,7 @@ tasks {
         pluginId = pkgsPluginId
         outputDir = generatedDir
         packageName = "com.jetbrains.packagesearch.plugin.core"
-        databaseVersion = 1
+        databaseVersion = 2
     }
     sourcesJar {
         dependsOn(generatePluginDataSources)

--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/extensions/Contexts.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/extensions/Contexts.kt
@@ -23,10 +23,7 @@ interface PackageSearchApiPackagesContext {
 }
 
 interface PackageSearchModuleBuilderContext :
-    ProjectContext, PackageSearchKnownRepositoriesContext, PackageSearchApiPackagesContext {
-        val projectCaches: CoroutineNitrite
-        val applicationCaches: CoroutineNitrite
-    }
+    ProjectContext, PackageSearchKnownRepositoriesContext, PackageSearchApiPackagesContext
 
 interface ProjectContext {
     val project: Project

--- a/plugin/gradle/base/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleProvider.kt
+++ b/plugin/gradle/base/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleProvider.kt
@@ -33,7 +33,9 @@ class GradleModuleProvider : AbstractGradleModuleProvider() {
             val configurationNames = model.configurations
                 .filter { it.canBeDeclared }
                 .map { it.name }
-            val declaredDependencies = module.getDeclaredDependencies()
+            val declaredDependencies = model.buildFilePath
+                ?.let { module.getDeclaredDependencies(it) }
+                ?: emptyList()
             val packageSearchGradleModule = PackageSearchGradleModule(
                 name = model.projectName,
                 identity = PackageSearchModule.Identity(

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleDependencyModel.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleDependencyModel.kt
@@ -1,39 +1,16 @@
 package com.jetbrains.packagesearch.plugin.gradle
 
 import com.jetbrains.packagesearch.plugin.core.extensions.DependencyDeclarationIndexes
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class GradleDependencyModel(
     val groupId: String,
     val artifactId: String,
     val version: String?,
     val configuration: String,
     val indexes: DependencyDeclarationIndexes,
-) {
+)
 
-    val packageId
-        get() = "maven:$groupId:$artifactId"
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as GradleDependencyModel
-
-        if (groupId != other.groupId) return false
-        if (artifactId != other.artifactId) return false
-        if (version != other.version) return false
-        if (configuration != other.configuration) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = groupId.hashCode()
-        result = 31 * result + artifactId.hashCode()
-        result = 31 * result + (version?.hashCode() ?: 0)
-        result = 31 * result + configuration.hashCode()
-        return result
-    }
-
-
-}
+val GradleDependencyModel.packageId
+    get() = "maven:$groupId:$artifactId"

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/GradleUtils.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/GradleUtils.kt
@@ -4,7 +4,9 @@ package com.jetbrains.packagesearch.plugin.gradle.utils
 
 import com.android.tools.idea.gradle.dsl.api.ProjectBuildModel
 import com.intellij.externalSystem.DependencyModifierService
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType
@@ -14,16 +16,24 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.jetbrains.packagesearch.plugin.core.data.IconProvider
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchModuleBuilderContext
+import com.jetbrains.packagesearch.plugin.core.nitrite.NitriteFilters
 import com.jetbrains.packagesearch.plugin.core.utils.IntelliJApplication
-import com.jetbrains.packagesearch.plugin.core.utils.asMavenApiPackage
+import com.jetbrains.packagesearch.plugin.core.utils.PackageSearchProjectCachesService
 import com.jetbrains.packagesearch.plugin.core.utils.filesChangedEventFlow
 import com.jetbrains.packagesearch.plugin.core.utils.icon
 import com.jetbrains.packagesearch.plugin.core.utils.mapUnit
 import com.jetbrains.packagesearch.plugin.core.utils.registryFlow
 import com.jetbrains.packagesearch.plugin.core.utils.watchExternalFileChanges
+import com.jetbrains.packagesearch.plugin.gradle.GradleDependencyModel
 import com.jetbrains.packagesearch.plugin.gradle.PackageSearchGradleDeclaredPackage
 import com.jetbrains.packagesearch.plugin.gradle.PackageSearchGradleModel
+import com.jetbrains.packagesearch.plugin.gradle.packageId
+import java.nio.file.Path
 import java.nio.file.Paths
+import korlibs.crypto.SHA256
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readBytes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.filter
@@ -31,6 +41,9 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
 import org.jetbrains.packagesearch.api.v3.ApiPackage
 import org.jetbrains.packagesearch.api.v3.ApiRepository
@@ -86,15 +99,73 @@ suspend fun Module.getDeclaredKnownRepositories(): Map<String, ApiRepository> {
     return knownRepositories.filterKeys { it in declaredDependencies }
 }
 
+@Serializable
+data class GradleDependencyModelCacheEntry(
+    @SerialName("_id") val id: Long? = null,
+    val buildFile: String,
+    val buildFileSha: String,
+    val dependencies: List<GradleDependencyModel>,
+)
+
 context(PackageSearchModuleBuilderContext)
-suspend fun Module.getDeclaredDependencies(): List<PackageSearchGradleDeclaredPackage> {
-    val declaredDependencies = readAction {
-        ProjectBuildModel.get(project).getModuleBuildModel(this)
+suspend fun retrieveGradleDependencyModel(nativeModule: Module, buildFile: Path): List<GradleDependencyModel> {
+    if (!buildFile.isRegularFile()) {
+        return emptyList()
+    }
+
+    val buildFileSha = SHA256.create()
+        .update(buildFile.readBytes())
+        .digest()
+        .hex
+
+    val cache = project.service<GradleCacheService>()
+        .dependencyRepository
+        .find(
+            filter = NitriteFilters.Object.eq(
+                path = GradleDependencyModelCacheEntry::buildFile,
+                value = buildFile.absolutePathString()
+            )
+        ).singleOrNull()
+
+    if (cache?.buildFileSha == buildFileSha) return cache.dependencies
+
+    val dependencies = readAction {
+        ProjectBuildModel.get(nativeModule.project).getModuleBuildModel(nativeModule)
             ?.dependencies()
             ?.artifacts()
             ?.map { it.toGradleDependencyModel() }
             ?: emptyList()
-    }.distinct()
+    }
+
+    project.service<GradleCacheService>()
+        .dependencyRepository
+        .update(
+            filter = NitriteFilters.Object.eq(
+                path = GradleDependencyModelCacheEntry::buildFile,
+                value = buildFile.absolutePathString()
+            ),
+            update = GradleDependencyModelCacheEntry(
+                buildFile = buildFile.absolutePathString(),
+                buildFileSha = buildFileSha,
+                dependencies = dependencies
+            ),
+            upsert = true
+        )
+
+    return dependencies
+}
+
+@Service(Service.Level.PROJECT)
+class GradleCacheService(project: Project) : Disposable {
+    val dependencyRepository =
+        project.PackageSearchProjectCachesService.getRepository<GradleDependencyModelCacheEntry>("gradle-dependencies")
+
+    override fun dispose() = dependencyRepository.close()
+}
+
+context(PackageSearchModuleBuilderContext)
+suspend fun Module.getDeclaredDependencies(buildFile: Path): List<PackageSearchGradleDeclaredPackage> {
+    val declaredDependencies = retrieveGradleDependencyModel(this, buildFile)
 
     val distinctIds = declaredDependencies
         .asSequence()

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Utils.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Utils.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.ModuleListener
 import com.intellij.openapi.project.Project
 import com.intellij.util.Function
+import com.intellij.util.flow.throttle
 import com.jetbrains.packagesearch.plugin.core.utils.FlowWithInitialValue
 import com.jetbrains.packagesearch.plugin.core.utils.flow
 import com.jetbrains.packagesearch.plugin.core.utils.withInitialValue
@@ -117,5 +118,19 @@ internal fun <T> timer(interval: Duration, generate: suspend () -> T) = flow {
     while (true) {
         emit(generate())
         delay(interval)
+    }
+}
+
+fun <T> Flow<T>.throttle(timeMs: Duration) =
+    throttle(timeMs.inWholeMilliseconds)
+
+fun <T> Flow<T>.drop(count: Int, function: (T) -> Boolean) = flow {
+    var current = 0
+    collect {
+        if (current < count && function(it)) {
+            current++
+        } else {
+            emit(it)
+        }
     }
 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/WindowedModuleBuilderContext.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/WindowedModuleBuilderContext.kt
@@ -39,8 +39,6 @@ class WindowedModuleBuilderContext(
     private val knownRepositoriesGetter: () -> Map<String, ApiRepository>,
     private val packagesCache: PackageSearchApi,
     override val coroutineScope: CoroutineScope,
-    override val projectCaches: CoroutineNitrite,
-    override val applicationCaches: CoroutineNitrite,
 ) : PackageSearchModuleBuilderContext {
 
     override val knownRepositories: Map<String, ApiRepository>


### PR DESCRIPTION
This update modifies the caching system and retrieval of modules in Gradle projects. It revamps the caching of declared dependencies by associating them with their SHA hash of the respective build file, and storing them in the local caches.