### PR TITLE
233 - Refactor code to add isSourceSet check in MavenModuleProvider

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
@@ -11,9 +11,12 @@ import com.intellij.openapi.extensions.AreaInstance
 import com.intellij.openapi.extensions.ExtensionPointListener
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginDescriptor
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataImportListener
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -354,5 +357,8 @@ class ProjectDataImportListenerAdapter(private val project: Project) : ProjectDa
         project.service<State>().value = false
     }
 }
+
+val Module.isSourceSet
+    get() = ExternalSystemApiUtil.getExternalModuleType(this) == "sourceSet"
 
 fun <T> Result<T>.suspendSafe() = onFailure { if (it is CancellationException) throw it }

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleTransformer.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/GradleModuleTransformer.kt
@@ -18,12 +18,12 @@ import com.jetbrains.packagesearch.plugin.core.utils.smartModeFlow
 import com.jetbrains.packagesearch.plugin.gradle.utils.awaitExternalSystemInitialization
 import com.jetbrains.packagesearch.plugin.gradle.utils.getModuleChangesFlow
 import com.jetbrains.packagesearch.plugin.gradle.utils.initializeProjectFlow
-import com.jetbrains.packagesearch.plugin.gradle.utils.isGradleSourceSet
+import com.jetbrains.packagesearch.plugin.gradle.utils.isGradle
 import com.jetbrains.packagesearch.plugin.gradle.utils.isResolveTask
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -50,7 +50,7 @@ abstract class AbstractGradleModuleProvider : PackageSearchModuleProvider {
         nativeModule: NativeModule,
     ): Flow<PackageSearchModule?> =
         merge(project.smartModeFlow, project.isProjectImportingFlow, project.initializeProjectFlow)
-            .filterNot { nativeModule.isGradleSourceSet }
+            .filter { nativeModule.isGradle }
             .mapNotNull {
                 findGradleModuleData(nativeModule)
                     ?.let { ExternalSystemApiUtil.find(it, PackageSearchGradleModel.DATA_NODE_KEY) }
@@ -97,5 +97,3 @@ class GradleSyncNotifierService : ExternalSystemTaskNotificationListenerAdapter(
         }
     }
 }
-
-

--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
@@ -1,22 +1,23 @@
 package com.jetbrains.packagesearch.plugin.gradle.utils
 
 import com.android.tools.idea.gradle.dsl.api.dependencies.ArtifactDependencyModel
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
 import com.intellij.openapi.externalSystem.service.project.manage.ExternalProjectsManager
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.jetbrains.packagesearch.plugin.core.extensions.DependencyDeclarationIndexes
+import com.jetbrains.packagesearch.plugin.core.utils.isSourceSet
 import com.jetbrains.packagesearch.plugin.gradle.GradleDependencyModel
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.plugins.gradle.util.GradleConstants
 
-val Module.isGradleSourceSet: Boolean
-    get() {
-        if (!ExternalSystemApiUtil.isExternalSystemAwareModule(GradleConstants.SYSTEM_ID, this)) return false
-        return ExternalSystemApiUtil.getExternalModuleType(this) == GradleConstants.GRADLE_SOURCE_SET_MODULE_TYPE_KEY
-    }
+private val GRADLE_SYSTEM_ID get() = ProjectSystemId("GRADLE")
+
+val Module.isGradle
+    get() = ExternalSystemApiUtil.isExternalSystemAwareModule(GradleConstants.SYSTEM_ID, this) && !isSourceSet
 
 suspend fun Project.awaitExternalSystemInitialization() = suspendCancellableCoroutine {
     ExternalProjectsManager.getInstance(this@awaitExternalSystemInitialization)


### PR DESCRIPTION
This commit introduces a critical change in the MavenModuleProvider. The provider now checks if a module is a source set before further processing, thereby improving avoiding duplicates with Gradle synthetic source sets. The isSourceSet check has also been incorporated into the Gradle module for consistency.