### PR TITLE
Update release channel in Gradle build file.

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -145,7 +145,7 @@ tasks {
         host = "https://tbe.labs.jb.gg/"
         token = project.properties["toolboxEnterpriseToken"]?.toString()
             ?: getenv("TOOLBOX_ENTERPRISE_TOKEN")
-        channels = listOf("Stable")
+        channels = listOf("Snapshots")
     }
 
     register<PublishPluginTask>("publishShadowPluginToMarketplace") {


### PR DESCRIPTION
The release channel in the Gradle build file has been updated from "Stable" to "Snapshots". This adjustment helps to accommodate the testing or development process that may require snapshot releases.