### PR TITLE
233 - Refine plugin publishing tasks in Gradle build.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,11 +18,18 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
       - uses: gradle/gradle-build-action@v2
-      - name: Run :publishShadowPlugin task
-        run: ./gradlew :plugin:publishShadowPluginToMarketplace publishAllPublicationsToSpaceRepository
+      - name: Run :publishShadowPluginToMarketplace task
+        run: ./gradlew publishAllPublicationsToSpaceRepository :plugin:publishPluginToMarketplace
         env:
           MARKETPLACE_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
           GRADLE_ENTERPRISE_KEY: ${{ secrets.GRADLE_ENTERPRISE_KEY }}
           MAVEN_SPACE_PASSWORD: ${{ secrets.MAVEN_SPACE_PASSWORD }}
           MAVEN_SPACE_USERNAME: ${{ secrets.MAVEN_SPACE_USERNAME }}
+          CHANGE_NOTES: ${{ github.event.release.body }}
+      - name: Run :publishStablePluginToTBE task
+        run: ./gradlew :plugin:publishReleasePluginToTBE
+        env:
+          KMP: true
+          TOOLBOX_ENTERPRISE_TOKEN: ${{ secrets.TOOLBOX_ENTERPRISE_TOKEN }}
+          GRADLE_ENTERPRISE_KEY: ${{ secrets.GRADLE_ENTERPRISE_KEY }}
           CHANGE_NOTES: ${{ github.event.release.body }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
           cache: gradle
       - uses: gradle/gradle-build-action@v2
       - name: Run :publishShadowPlugin task
-        run: ./gradlew :plugin:publishShadowPlugin publishAllPublicationsToSpaceRepository
+        run: ./gradlew :plugin:publishSnapshotPluginToTBE publishAllPublicationsToSpaceRepository
         env:
           TOOLBOX_ENTERPRISE_TOKEN: ${{ secrets.TOOLBOX_ENTERPRISE_TOKEN }}
           GRADLE_ENTERPRISE_KEY: ${{ secrets.GRADLE_ENTERPRISE_KEY }}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -138,17 +138,27 @@ tasks {
         destinationDirectory = layout.buildDirectory.dir("distributions")
     }
 
-    register<PublishPluginTask>("publishShadowPlugin") {
+    register<PublishPluginTask>("publishSnapshotPluginToTBE") {
         group = "publishing"
         distributionFile = buildShadowPlugin.flatMap { it.archiveFile }
         toolboxEnterprise = true
         host = "https://tbe.labs.jb.gg/"
         token = project.properties["toolboxEnterpriseToken"]?.toString()
             ?: getenv("TOOLBOX_ENTERPRISE_TOKEN")
-        channels = listOf("Snapshots")
+        channels = listOf("Snapshot")
     }
 
-    register<PublishPluginTask>("publishShadowPluginToMarketplace") {
+    register<PublishPluginTask>("publishReleasePluginToTBE") {
+        group = "publishing"
+        distributionFile = buildShadowPlugin.flatMap { it.archiveFile }
+        toolboxEnterprise = true
+        host = "https://tbe.labs.jb.gg/"
+        token = project.properties["toolboxEnterpriseToken"]?.toString()
+            ?: getenv("TOOLBOX_ENTERPRISE_TOKEN")
+        channels = listOf("Release")
+    }
+
+    register<PublishPluginTask>("publishPluginToMarketplace") {
         group = "publishing"
         distributionFile = buildShadowPlugin.flatMap { it.archiveFile }
         token = project.properties["marketplaceToken"]?.toString()


### PR DESCRIPTION
This change separates plugin publishing tasks for snapshot and release builds, and pushes them to separate Toolbox Enterprise channels. It also updates the corresponding GitHub workflows accordingly. This provides more flexibility and control over plugin release processes.