### PR TITLE
233 - Fix http headers for http requests.

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchApplicationCachesService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchApplicationCachesService.kt
@@ -26,7 +26,7 @@ import io.ktor.client.engine.java.Java
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.http.headers
+import io.ktor.client.request.headers
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.div


### PR DESCRIPTION
Previously the function io.ktor.http.headers was used which is very wrong, since it does not register any header.