### PR TITLE
241 - FIX PKGS-1399 Set retry limit in various ViewModel classes

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchFUSService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchFUSService.kt
@@ -23,7 +23,7 @@ class PackageSearchFUSService(coroutineScope: CoroutineScope) {
     init {
         fusEventsFlow
             .onEach { it.log() }
-            .retry {
+            .retry(5) {
                 logWarn("${this::class.qualifiedName}#eventReportingJob", it) { "Failed to log FUS" }
                 true
             }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchProjectService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchProjectService.kt
@@ -12,7 +12,6 @@ import com.intellij.psi.PsiManager
 import com.jetbrains.packagesearch.plugin.PackageSearchModuleBaseTransformerUtils
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchKnownRepositoriesContext
 import com.jetbrains.packagesearch.plugin.core.utils.IntelliJApplication
-import com.jetbrains.packagesearch.plugin.core.utils.PackageSearchProjectCachesService
 import com.jetbrains.packagesearch.plugin.core.utils.fileOpenedFlow
 import com.jetbrains.packagesearch.plugin.core.utils.replayOn
 import com.jetbrains.packagesearch.plugin.core.utils.toolWindowOpenedFlow
@@ -79,7 +78,7 @@ class PackageSearchProjectService(
             .getKnownRepositories()
             .associateBy { it.id }
     }
-        .retry {
+        .retry(5) {
             logWarn("${this::class.simpleName}#knownRepositoriesStateFlow", throwable = it)
             true
         }
@@ -169,7 +168,7 @@ class PackageSearchProjectService(
             .filter { it }
             .throttle(30.minutes)
             .onEach { restart() }
-            .retry {
+            .retry(5) {
                 logWarn("${this::class.simpleName}#isOnlineFlow", throwable = it)
                 true
             }
@@ -188,7 +187,7 @@ class PackageSearchProjectService(
                         ?.let { DaemonCodeAnalyzer.getInstance(project).restart(it) }
                 }
             }
-            .retry {
+            .retry(5) {
                 logWarn("${this::class.simpleName}#fileOpenedFlow", throwable = it)
                 true
             }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/ToolWindowViewModel.kt
@@ -82,7 +82,7 @@ class ToolWindowViewModel(project: Project, private val viewModelScope: Coroutin
             else -> PackageSearchToolWindowState.NoModules
         }
     }
-        .retry()
+        .retry(5)
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Lazily,

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
@@ -74,7 +74,7 @@ class InfoPanelViewModel(
             }
         }
     }
-        .retry()
+        .retry(5)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val activeTabTitleMutableStateFlow: MutableStateFlow<String?> = MutableStateFlow(null)

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListViewModel.kt
@@ -170,7 +170,7 @@ class PackageListViewModel(
                 current
             }
         }
-        .retry()
+        .retry(5)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
     val selectableLazyListState = SelectableLazyListState(LazyListState())
@@ -202,7 +202,7 @@ class PackageListViewModel(
                     }
                 }
             }
-            .retry()
+            .retry(5)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
     private suspend fun PackageSearchModule.Base.getSearchQuery(

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/tree/TreeViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/tree/TreeViewModel.kt
@@ -33,7 +33,7 @@ internal class TreeViewModel(
     ) { modules, stableOnly ->
         modules.asTree(stableOnly)
     }
-        .retry()
+        .retry(5)
         .onEach { logDebug("${this::class.qualifiedName}#treeStateFlow") { it.print() } }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyTree())
 


### PR DESCRIPTION
This commit sets the retry attempts from default (unlimited) to 5 in several classes. The change improves error handling by preventing potential infinite loops in case of persistent failures.