### PR TITLE
Refactor settings to be persisted on disk

### DIFF
--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/services/PackageSearchProjectCachesService.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/services/PackageSearchProjectCachesService.kt
@@ -4,10 +4,10 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.Service.Level
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.getProjectDataPath
 import com.jetbrains.packagesearch.plugin.core.PackageSearch
 import com.jetbrains.packagesearch.plugin.core.nitrite.buildDefaultNitrate
 import com.jetbrains.packagesearch.plugin.core.utils.PKGSInternalAPI
+import com.jetbrains.packagesearch.plugin.core.utils.packageSearchProjectDataPath
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.div
 
@@ -15,21 +15,12 @@ import kotlin.io.path.div
 class PackageSearchProjectCachesService(private val project: Project) : Disposable {
 
     private val cacheFilePath
-        get() = cachesDirectory / "db-v${PackageSearch.databaseVersion}.db"
-
-    private val cachesDirectory
-        get() = project.getProjectDataPath("caches") / "packagesearch"
+        get() = project.packageSearchProjectDataPath / "caches-v${PackageSearch.databaseVersion}.db"
 
     @PKGSInternalAPI
-    val cache = buildDefaultNitrate(
-        path = cacheFilePath
-            .apply { parent.toFile().mkdirs() }
-            .absolutePathString()
-    )
+    val cache = buildDefaultNitrate(cacheFilePath.absolutePathString())
 
-    override fun dispose() {
-        cache.close()
-    }
+    override fun dispose() = cache.close()
 
     inline fun <reified T : Any> getRepository(key: String) =
         cache.getRepository<T>(key)

--- a/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
+++ b/plugin/core/src/main/kotlin/com/jetbrains/packagesearch/plugin/core/utils/Utils.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.extensions.AreaInstance
 import com.intellij.openapi.extensions.ExtensionPointListener
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginDescriptor
-import com.intellij.openapi.externalSystem.model.ProjectSystemId
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataImportListener
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -19,6 +18,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.getProjectDataPath
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.registry.RegistryManager
@@ -39,27 +39,23 @@ import com.intellij.util.messages.Topic
 import com.jetbrains.packagesearch.plugin.core.data.IconProvider
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredMavenPackage
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredPackage
-import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDeclaredRepository
 import com.jetbrains.packagesearch.plugin.core.services.PackageSearchProjectCachesService
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.contracts.contract
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.resume
+import kotlin.io.path.createDirectories
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.jetbrains.packagesearch.api.v3.ApiMavenPackage
@@ -374,3 +370,6 @@ fun <T> Result<T>.suspendSafe() = onFailure { if (it is CancellationException) t
 
 fun Path.isSameFileAsSafe(other: Path): Boolean = kotlin.runCatching { Files.isSameFile(this, other) }
     .getOrDefault(false)
+
+val Project.packageSearchProjectDataPath
+    get() = getProjectDataPath("packagesearch").createDirectories()

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/inspections/PackageUpdateInspection.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/inspections/PackageUpdateInspection.kt
@@ -42,6 +42,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchDependencyManag
 import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModule
 import com.jetbrains.packagesearch.plugin.core.extensions.PackageSearchKnownRepositoriesContext
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchProjectService
+import com.jetbrains.packagesearch.plugin.utils.PackageSearchSettingsService
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.Nls
 import org.jetbrains.packagesearch.packageversionutils.normalization.NormalizedVersion
@@ -130,7 +131,7 @@ class PackageUpdateInspection : PackageSearchInspection() {
                         ?: return@inner
 
                 val targetVersion = when {
-                    project.PackageSearchProjectService.stableOnlyStateFlow.value ->
+                    project.PackageSearchSettingsService.stableOnlyFlow.value ->
                         dependency.remoteInfo?.versions?.latestStable
 
                     else -> dependency.remoteInfo?.versions?.latest
@@ -166,7 +167,7 @@ class PackageUpdateInspection : PackageSearchInspection() {
                                     newVersion = targetVersion.normalized.versionName,
                                     newScope = dependency.declaredScope
                                 )
-                                if (project.PackageSearchProjectService.installRepositoryIfNeeded.value) {
+                                if (project.PackageSearchSettingsService.installRepositoryIfNeededFlow.value) {
                                     targetVersion.repositoryIds
                                         .firstNotNullOfOrNull { project.PackageSearchProjectService.knownRepositories[it] }
                                         ?.takeIf { it.url !in module.declaredRepositories.map { it.url } }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchSettingsService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchSettingsService.kt
@@ -1,0 +1,101 @@
+package com.jetbrains.packagesearch.plugin.services
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.Service.Level
+import com.intellij.openapi.project.Project
+import com.jetbrains.packagesearch.plugin.core.utils.packageSearchProjectDataPath
+import com.jetbrains.packagesearch.plugin.ui.PackageSearchMetrics
+import com.jetbrains.packagesearch.plugin.utils.logDebug
+import kotlin.io.path.div
+import kotlin.io.path.inputStream
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+
+@Service(Level.PROJECT)
+class PackageSearchSettingsService(private val project: Project, private val coroutineScope: CoroutineScope) {
+
+    private val settingsFile
+        get() = project.packageSearchProjectDataPath / "settings.json"
+
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private fun loadSettings() =
+        kotlin.runCatching { json.decodeFromStream<Settings>(settingsFile.inputStream()) }
+            .onSuccess { logDebug { "Settings loaded: \n${settingsFile.readText()}" } }
+            .map { it.asSafe() }
+            .onFailure { logDebug("Failed to load settings", it) }
+            .getOrElse { Settings() }
+
+    private suspend fun Settings.save() =
+        withContext(Dispatchers.IO) { settingsFile.writeText(json.encodeToString(this@save)) }
+
+    val stableOnlyFlow: MutableStateFlow<Boolean>
+    val installRepositoryIfNeededFlow: MutableStateFlow<Boolean>
+    val isInfoPanelOpenFlow: MutableStateFlow<Boolean>
+    val firstSplitPanePositionFlow: MutableStateFlow<Float>
+    val secondSplitPanePositionFlow: MutableStateFlow<Float>
+
+    init {
+
+        val initialSettings = loadSettings()
+
+        stableOnlyFlow = MutableStateFlow(initialSettings.onlyStable)
+        installRepositoryIfNeededFlow = MutableStateFlow(initialSettings.installRepositoryIfNeeded)
+        isInfoPanelOpenFlow = MutableStateFlow(initialSettings.isInfoPanelOpen)
+        firstSplitPanePositionFlow = MutableStateFlow(initialSettings.firstSplitPanePosition.coerceIn(0f, 1f))
+        secondSplitPanePositionFlow = MutableStateFlow(initialSettings.secondSplitPanePosition.coerceIn(0f, 1f))
+
+        combine(
+            stableOnlyFlow,
+            installRepositoryIfNeededFlow,
+            isInfoPanelOpenFlow,
+            firstSplitPanePositionFlow,
+            secondSplitPanePositionFlow,
+        ) {
+                stableOnly, installRepositoryIfNeeded, isInfoPanelOpen,
+                firstSplitPanePosition, secondSplitPanePosition,
+            ->
+            Settings(
+                onlyStable = stableOnly,
+                installRepositoryIfNeeded = installRepositoryIfNeeded,
+                isInfoPanelOpen = isInfoPanelOpen,
+                firstSplitPanePosition = firstSplitPanePosition,
+                secondSplitPanePosition = secondSplitPanePosition,
+            )
+        }
+            .debounce(1.seconds)
+            .onEach { it.save() }
+            .launchIn(coroutineScope)
+    }
+}
+
+@Serializable
+private data class Settings(
+    val onlyStable: Boolean = false,
+    val installRepositoryIfNeeded: Boolean = true,
+    val isInfoPanelOpen: Boolean = false,
+    val firstSplitPanePosition: Float = PackageSearchMetrics.Splitpanes.firstSplitPositionPercentage,
+    val secondSplitPanePosition: Float = PackageSearchMetrics.Splitpanes.secondSplitPositionPercentage,
+) {
+    fun asSafe() = copy(
+        firstSplitPanePosition = firstSplitPanePosition.coerceIn(0f, 1f),
+        secondSplitPanePosition = secondSplitPanePosition.coerceIn(0f, 1f),
+    )
+}

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchMetrics.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchMetrics.kt
@@ -19,12 +19,12 @@ object PackageSearchMetrics {
                     metrics.trackPadding.calculateEndPadding(LocalLayoutDirection.current)
         }
 
-    object Splitpane {
+    object Splitpanes {
 
         val minWidth: Dp = 300.dp
-        const val firstSplitterPositionPercentage = .20f
+        const val firstSplitPositionPercentage = .20f
 
-        const val secondSplittePositionPercentage = .80f
+        const val secondSplitPositionPercentage = .80f
     }
 
     object Popups {

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchPackagePanel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/PackageSearchPackagePanel.kt
@@ -27,18 +27,18 @@ fun PackageSearchPackagePanel(
     val innerSplitPaneState by remember { toolWindowsViewModel.secondSplitPaneState }
 
     HorizontalSplitPane(Modifier.fillMaxSize(), splitPaneState) {
-        first(PackageSearchMetrics.Splitpane.minWidth) {
+        first(PackageSearchMetrics.Splitpanes.minWidth) {
             PackageSearchModulesTree(Modifier, onSelectionModulesSelectionChanged)
         }
         packageSearchSplitter()
         second {
             if (isInfoPanelOpen) {
                 HorizontalSplitPane(Modifier.fillMaxSize(), innerSplitPaneState) {
-                    first(PackageSearchMetrics.Splitpane.minWidth) {
+                    first(PackageSearchMetrics.Splitpanes.minWidth) {
                         PackageSearchCentralPanel(onLinkClick = onLinkClick)
                     }
                     packageSearchSplitter()
-                    second(PackageSearchMetrics.Splitpane.minWidth) {
+                    second(PackageSearchMetrics.Splitpanes.minWidth) {
                         PackageSearchInfoPanel(onLinkClick = onLinkClick, onPackageEvent = onPackageEvent)
                     }
                 }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/infopanel/InfoPanelViewModel.kt
@@ -11,6 +11,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModuleVariant
 import com.jetbrains.packagesearch.plugin.ui.model.packageslist.PackageListItem
 import com.jetbrains.packagesearch.plugin.ui.model.packageslist.PackageListViewModel
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchProjectService
+import com.jetbrains.packagesearch.plugin.utils.PackageSearchSettingsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,7 +43,7 @@ class InfoPanelViewModel(
 
     val tabs: StateFlow<List<InfoPanelContent>> = combine(
         setDataEventChannel.consumeAsFlow(),
-        project.PackageSearchProjectService.stableOnlyStateFlow,
+        project.PackageSearchSettingsService.stableOnlyFlow,
         packageLoadingState
     ) { event, onlyStable, packageLoadingState ->
         when (event) {

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/tree/TreeViewModel.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/tree/TreeViewModel.kt
@@ -8,6 +8,7 @@ import com.jetbrains.packagesearch.plugin.core.data.PackageSearchModule
 import com.jetbrains.packagesearch.plugin.core.utils.IntelliJApplication
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchApplicationCachesService
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchProjectService
+import com.jetbrains.packagesearch.plugin.utils.PackageSearchSettingsService
 import com.jetbrains.packagesearch.plugin.utils.logDebug
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -29,7 +30,7 @@ internal class TreeViewModel(
 
     val treeStateFlow: StateFlow<Tree<TreeItemModel>> = combine(
         project.PackageSearchProjectService.modulesStateFlow,
-        project.PackageSearchProjectService.stableOnlyStateFlow
+        project.PackageSearchSettingsService.stableOnlyFlow
     ) { modules, stableOnly ->
         modules.asTree(stableOnly)
     }

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Services.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/utils/Services.kt
@@ -8,6 +8,7 @@ import com.jetbrains.packagesearch.plugin.fus.PackageSearchFUSEvent
 import com.jetbrains.packagesearch.plugin.services.PackageSearchApplicationCachesService
 import com.jetbrains.packagesearch.plugin.services.PackageSearchFUSService
 import com.jetbrains.packagesearch.plugin.services.PackageSearchProjectService
+import com.jetbrains.packagesearch.plugin.services.PackageSearchSettingsService
 
 
 val Application.PackageSearchApplicationCachesService
@@ -15,6 +16,9 @@ val Application.PackageSearchApplicationCachesService
 
 val Project.PackageSearchProjectService
     get() = service<PackageSearchProjectService>()
+
+val Project.PackageSearchSettingsService
+    get() = service<PackageSearchSettingsService>()
 
 val Application.PackageSearchFUSService
     get() = service<PackageSearchFUSService>()


### PR DESCRIPTION
Implements [PKGS-1423](https://youtrack.jetbrains.com/issue/PKGS-1423) Create storable settings

This change moves settings to be stored on disk in a new `PackageSearchSettingsService`. This service is responsible for managing options such as filtering for stable packages, installing repositories automatically, and keeping state for UI panel positions. This enables settings to be remembered across IDE restarts. Also, related code has been updated to switch from previous locations to use these persisted settings.