### PR TITLE
Fix PKGS-1422 version outdate problem registering for groovy-gradle files

### DIFF
--- a/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
+++ b/plugin/gradle/src/main/kotlin/com/jetbrains/packagesearch/plugin/gradle/utils/Utils.kt
@@ -33,7 +33,8 @@ private fun ArtifactDependencyModel.getDependencyDeclarationIndexes(): Dependenc
             ?.textOffset
             ?: psiElement!!.textOffset,
         versionStartIndex = version().psiElement?.textOffset
-            ?: psiElement?.children?.firstOrNull()?.textOffset,
+            ?: psiElement?.children?.firstOrNull()?.textOffset
+            ?: psiElement?.textOffset,
     )
 
 fun ArtifactDependencyModel.toGradleDependencyModel() =


### PR DESCRIPTION
It fixes [PKGS-1422 ](https://youtrack.jetbrains.com/issue/PKGS-1422/Hints-for-build-files-can-be-wrong)the calculation of the version text offset by adding a fallback to the parent psiElement's offset if no child elements are present