### PR TITLE
241 - Add 'No Packages Found' view to Package List UI

### DIFF
--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItem.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/ui/model/packageslist/PackageListItem.kt
@@ -157,4 +157,13 @@ sealed interface PackageListItem {
         ) : PackageListItem.Id
     }
 
+    data class NoPackagesFound(override val id: Id) : PackageListItem {
+
+        @Serializable
+        data class Id(
+            override val moduleIdentity: PackageSearchModule.Identity,
+            val parentHeaderId: Header.Id,
+        ) : PackageListItem.Id
+    }
+
 }

--- a/plugin/src/main/resources/messages/packageSearchBundle.properties
+++ b/plugin/src/main/resources/messages/packageSearchBundle.properties
@@ -196,6 +196,7 @@ packagesearch.ui.toolwindow.packages.sort.by=Sort by:
 packagesearch.ui.toolwindow.tab.packages.installedPackages.addedIn=Added in {0}
 packagesearch.ui.toolwindow.tab.packages.searchResults=Search Results
 packagesearch.ui.toolwindow.tab.packages.searchResults.error=An error occurred while searching for dependencies.
+packagesearch.ui.toolwindow.tab.packages.searchResults.noPackages=No packages found.
 packagesearch.ui.toolwindow.tab.packages.searchResults.error.retry=Try again
 packagesearch.ui.toolwindow.tab.packages.selectedPackage=Selected dependency
 packagesearch.ui.toolwindow.tab.packages.title=Manage


### PR DESCRIPTION
This commit introduces a new view in the package search results for the case when no packages are found. The update includes a 'NoPackagesFoundItem' Composable function, and respective user interface changes. The 'NoPackagesFound' class added to the 'PackageListItem' differentiates between errors and no results in package searches.