### PR TITLE
233 - Disable version catalog test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
           name: testResult-kmp-gradle-${{ matrix.os }}-${{ matrix.gradle-version }}
           path: /home/runner/work/package-search-intellij-plugin/package-search-intellij-plugin/plugin/build/testData
   version-catalog:
+    if: false # Disabled until we make an effort to fix catalogs
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
The version catalog workflow in the GitHub Actions pipeline has been temporarily disabled. This action was necessary due to pending fixes - the effort to make these fixes has not yet been made. Consequently, until these issues are resolved, the version catalog test workflow will remain inoperative.