### PR TITLE
Add UserAgent to Ktor client and remove GITHUB_REF from run settings

### DIFF
--- a/.run/[KMP] Package Search Plugin.run.xml
+++ b/.run/[KMP] Package Search Plugin.run.xml
@@ -4,7 +4,6 @@
     <ExternalSystemSettings>
       <option name="env">
         <map>
-          <entry key="GITHUB_REF" value="refs/tags/241.0.10" />
           <entry key="KMP" value="true" />
         </map>
       </option>

--- a/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchApplicationCachesService.kt
+++ b/plugin/src/main/kotlin/com/jetbrains/packagesearch/plugin/services/PackageSearchApplicationCachesService.kt
@@ -24,6 +24,7 @@ import com.jetbrains.packagesearch.plugin.utils.PackageSearchLogger
 import com.jetbrains.packagesearch.plugin.utils.PackageSearchProjectService
 import io.ktor.client.engine.java.Java
 import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.UserAgent
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.headers
@@ -97,6 +98,9 @@ class PackageSearchApplicationCachesService(private val coroutineScope: Coroutin
                     append("JB-Plugin-Version", PackageSearch.pluginVersion)
                     append("JB-IDE-Version", IntelliJApplication.service<ApplicationInfo>().strictVersion)
                 }
+            }
+            install(UserAgent) {
+                agent = IntelliJApplication.service<ApplicationInfo>().fullApplicationName
             }
         }
     )


### PR DESCRIPTION
The commit introduces a new UserAgent to the Ktor client within the PackageSearchApplicationCachesService.kt for the IntelliJApplication. The UserAgent is set using fullApplicationName coming from the service ApplicationInfo. On a different note, an unused environment variable GITHUB_REF has been removed from the Plugin.run.xml configuration file, for cleanup purposes.