### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,6 +31,14 @@ jobs:
           distribution: 'zulu'
       - uses: gradle/gradle-build-action@v3
       - name: Publish libraries
+        id: simple-build-publish
+        continue-on-error: true
+        run: ./gradlew publishAllPublicationsToSpaceRepository
+      - name: Patch IDE config files
+        if: steps.simple-build-publish.outcome == 'failure'
+        run: kotlinc -script ./.github/workflows/TrustKotlinGradlePluginPatch.main.kts
+      - name: Publish libraries
+        if: steps.simple-build-publish.outcome == 'failure'
         run: ./gradlew publishAllPublicationsToSpaceRepository
       - name: Publish release plugin to TBE
         env:


### PR DESCRIPTION
Added new steps in the GitHub Actions workflow to ensure continued operation in case of failures during the library publishing process. If a failure occurs while running the 'publishAllPublicationsToSpaceRepository' gradle task, the workflow will subsequently patch IDE config files and attempt to re-publish the libraries. This ensures resilience in our CI/CD process.