### PR TITLE
Temporarily disabled suffix addition in plugin's build file

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -135,7 +135,7 @@ tasks {
             ?.let { Parser.builder().build().parse(it) }
             ?.let { HtmlRenderer.builder().build().render(it) }
             ?.prefixIfNot("<![CDATA[")
-            ?.suffixIfNot("]]>")
+//            ?.suffixIfNot("]]>")
 
     }
 


### PR DESCRIPTION
In the 'plugin/build.gradle.kts' file, the functionality that adds the ']]>' suffix has been temporarily disabled. Further code investigation is needed to determine the impact of this feature.