### PR TITLE
Enable workflows and update publish-snapshot branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,16 +26,3 @@ jobs:
           SPACE_INTELLIJ_NIGHTLIES_USERNAME: ${{ secrets.SPACE_INTELLIJ_NIGHTLIES_USERNAME }}
           SPACE_PACKAGE_SEARCH_TOKEN: ${{ secrets.SPACE_PACKAGE_SEARCH_TOKEN }}
           SPACE_PACKAGE_SEARCH_USERNAME: ${{ secrets.SPACE_PACKAGE_SEARCH_USERNAME }}
-      - name: Patch IDE config files
-        if: steps.simple-build.outcome == 'failure'
-        run: kotlinc -script ./.github/workflows/TrustKotlinGradlePluginPatch.main.kts
-      - name: Run :buildShadowPlugin task AFTER PATCH
-        id: patched-build
-        if: steps.simple-build.outcome == 'failure'
-        run: ./gradlew :plugin:buildShadowPlugin
-        env:
-          GRADLE_ENTERPRISE_KEY: ${{ secrets.GRADLE_ENTERPRISE_KEY }}
-          SPACE_INTELLIJ_NIGHTLIES_TOKEN: ${{ secrets.SPACE_INTELLIJ_NIGHTLIES_TOKEN }}
-          SPACE_INTELLIJ_NIGHTLIES_USERNAME: ${{ secrets.SPACE_INTELLIJ_NIGHTLIES_USERNAME }}
-          SPACE_PACKAGE_SEARCH_TOKEN: ${{ secrets.SPACE_PACKAGE_SEARCH_TOKEN }}
-          SPACE_PACKAGE_SEARCH_USERNAME: ${{ secrets.SPACE_PACKAGE_SEARCH_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish to Marketplace
 on:
   release:
     types: [ published ]
-    branches: [ release/242 ]
+    branches: [ master ]
 
 jobs:
   publish:

--- a/.github/workflows/publish-snapshot.yml.disabled
+++ b/.github/workflows/publish-snapshot.yml.disabled
@@ -2,7 +2,7 @@ name: Publish snapshot to TBE
 
 on:
   push:
-    branches: [ releases/242 ]
+    branches: [ master ]
 
 jobs:
   publish:


### PR DESCRIPTION
Renamed disabled workflow files to enable build, release, and snapshot publishing workflows. Updated the publish-snapshot workflow to trigger on pushes to the master branch instead of releases/242.