### PR TITLE
Remove redundant Gradle publish steps

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,8 +30,6 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
       - uses: gradle/gradle-build-action@v3
-      - name: Publish libraries
-        run: ./gradlew publishAllPublicationsToSpaceRepository
       - name: Publish release plugin to TBE
         env:
           KMP: true

--- a/.github/workflows/publish-snapshot.yml.disabled
+++ b/.github/workflows/publish-snapshot.yml.disabled
@@ -30,7 +30,5 @@ jobs:
           distribution: 'zulu'
           cache: gradle
       - uses: gradle/gradle-build-action@v2
-      - name: Publish libraries
-        run: ./gradlew publishAllPublicationsToSpaceRepository
       - name: Publish plugin snapshot to TBE
         run: ./gradlew :plugin:publishSnapshotPluginToTBE


### PR DESCRIPTION
Removed duplicate steps that publish libraries from GitHub workflows `publish-release.yml` and `publish-snapshot.yml.disabled`. This cleanup ensures that only the necessary steps for publishing to TBE are executed, simplifying the workflows.